### PR TITLE
Fix for calc_inv_vol_weights() in case of zero volatility

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1265,11 +1265,15 @@ def calc_inv_vol_weights(returns):
     volatility resulting in a set of portfolio weights where each position
     has the same level of volatility.
 
+    Note, that assets with returns all equal to NaN or 0 are excluded from
+    the portfolio (their weight is set to NaN).
+
     Returns:
         Series {col_name: weight}
     """
     # calc vols
     vol = 1.0 / returns.std()
+    vol[np.isinf(vol)] = np.NaN
     vols = vol.sum()
     return vol / vols
 


### PR DESCRIPTION
If some returns series supplied to `calc_inv_vol_weights()` are equal to zero, then inverse-volatility will be infinite.

I suggest to remove assets with zero volatility from the portfolio rather than returning a list of zeros (sum of all weights will be also infinite -> individual weights of good assets are equal to zero).

There're three options:
- we can drop these assets (`dropna()` [here](https://github.com/vfilimonov/ffn/commit/91e89982579c06f83a61ae1dac134cfdeb5e1e83#diff-a34fa4843ef91ea804e63075ff7565d4R1278))
- we can set their weights to zero  (`fillna(0)` [here](https://github.com/vfilimonov/ffn/commit/91e89982579c06f83a61ae1dac134cfdeb5e1e83#diff-a34fa4843ef91ea804e63075ff7565d4R1278))
- we can return `NaN` for them

I think the last variant is better: user might expect series of the same structure as the initial dataframe with returns, so `dropna()` is not good. Also it is consistent with the following situation: if we pass a series of `NaN` then this weight will be equal to `NaN`