### PR TITLE
Fix for limit_weights in case when ok.sum() is zero

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1543,6 +1543,8 @@ def limit_weights(weights, limit=0.1):
     Limits weights and redistributes excedent amount
     proportionally.
 
+    Note that the method works only for positive weights.
+
     ex:
         - weights are {a: 0.7, b: 0.2, c: 0.1}
         - call with limit=0.5
@@ -1568,7 +1570,10 @@ def limit_weights(weights, limit=0.1):
     to_rebalance = (res[res > limit] - limit).sum()
 
     ok = res[res < limit]
-    ok += (ok / ok.sum()) * to_rebalance
+    if all(ok == 0):
+        ok += to_rebalance / float(len(ok))
+    else:
+        ok += (ok / ok.sum()) * to_rebalance
 
     res[res > limit] = limit
     res[res < limit] = ok


### PR DESCRIPTION
The original method crashes when `ok.sum()==0`. For example:
```
x = [1e-17, 1e-17, 0.15, 1e-16, 0.35, 
     1e-17, 1e-17, 0.15, 1e-16, 0.35,
     1e-17, 1e-17, 0.15, 1e-16, 0.35,
     1e-17, 1e-17, 0.15, 1e-16, 0.35,
     1e-17, 1e-17, 0.15, 1e-16, 0.35,]
x = np.array(x) / sum(x)

ffn.limit_weights(x, limit=0.05)  # ValueError: Expecting weights (that sum to 1) - sum is nan
```

This fixes this behavior, by equally redistributed weight in case when `all(ok==0)`.

Also, this method looks to work only when weights are positive. For example, `ok.sum()==0` might be also in case when we have `ok=[-0.1, -0.1, 0.1, 0.1]`. But anyway, redistribution for negative weights does not make much sense. Perhaps we should have a warning like:
```
    res = np.round(weights.copy(), 4)
    if any(res < 0):
         # Warn here that the outcome might be not as expected
```