### PR TITLE
fix divide by zero error when less than 12 months but spanning a year…

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -311,8 +311,9 @@ class PerformanceStats(object):
 
         self.yearly_mean = yr.mean()
         self.yearly_vol = yr.std()
-        self.yearly_sharpe = ((self.yearly_mean - self._yearly_rf) /
-                              self.yearly_vol)
+        if self.yearly_vol > 0:
+            self.yearly_sharpe = ((self.yearly_mean - self._yearly_rf) /
+                                  self.yearly_vol)
         self.best_year = yr.max()
         self.worst_year = yr.min()
 

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -322,13 +322,15 @@ class PerformanceStats(object):
         # -1 here to account for first return that will be nan
         self.win_year_perc = len(yr[yr > 0]) / float(len(yr) - 1)
 
-        tot = 0
-        win = 0
-        for i in range(11, len(mr)):
-            tot = tot + 1
-            if mp[i] / mp[i - 11] > 1:
-                win = win + 1
-        self.twelve_month_win_perc = float(win) / tot
+        # need at least 1 year of monthly returns
+        if mr.size > 11:
+            tot = 0
+            win = 0
+            for i in range(11, len(mr)):
+                tot += 1
+                if mp[i] / mp[i - 11] > 1:
+                    win += 1
+            self.twelve_month_win_perc = float(win) / tot
 
         if len(yr) < 4:
             return

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -499,10 +499,18 @@ def test_annualize():
 
 
 def test_calc_stats():
+    # test twelve_month_win_perc divide by zero
     prices = df.C['2010-10-01':'2011-08-01']
     stats = ffn.calc_stats(prices).stats
-    print(stats.index)
     assert 'twelve_month_win_perc' not in stats.index
     prices = df.C['2009-10-01':'2011-08-01']
     stats = ffn.calc_stats(prices).stats
     assert 'twelve_month_win_perc' in stats.index
+
+    # test yearly_sharpe divide by zero
+    prices = df.C['2009-01-01':'2012-01-01']
+    stats = ffn.calc_stats(prices).stats
+    assert 'yearly_sharpe' in stats.index
+    prices[prices > 0.0] = 1.0
+    stats = ffn.calc_stats(prices).stats
+    assert 'yearly_sharpe' not in stats.index

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -496,3 +496,13 @@ def test_rescale():
 
 def test_annualize():
     assert ffn.annualize(0.1, 60) == (1.1 ** (1. / (60. / 365)) - 1)
+
+
+def test_calc_stats():
+    prices = df.C['2010-10-01':'2011-08-01']
+    stats = ffn.calc_stats(prices).stats
+    print(stats.index)
+    assert 'twelve_month_win_perc' not in stats.index
+    prices = df.C['2009-10-01':'2011-08-01']
+    stats = ffn.calc_stats(prices).stats
+    assert 'twelve_month_win_perc' in stats.index


### PR DESCRIPTION
Thanks for the great library!

Encountered this divide by zero error when calculating stats on moving windows smaller than a year and went ahead and fixed it. The test provided should fail on the current master, but pass with this pull request.

Let me know if this works for you.

Chris
