### PR TITLE
fixed an AttributeError in ffn.calc_clusters

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1451,9 +1451,14 @@ def calc_clusters(returns, n=None, plot=False):
     tmp = result[0]
     # map as such {cluster: [list of tickers], cluster2: [...]}
     inv_map = {}
-    for k, v in tmp.iteritems():
-        inv_map[v] = inv_map.get(v, [])
-        inv_map[v].append(k)
+    try:
+        for k, v in tmp.iteritems():
+            inv_map[v] = inv_map.get(v, [])
+            inv_map[v].append(k)
+    except AttributeError:
+        for k, v in tmp.items():
+            inv_map[v] = inv_map.get(v, [])
+            inv_map[v].append(k)
 
     return inv_map
 


### PR DESCRIPTION
notice that .iteritems() has been abolished in python 3.x,using .items() instead when AttributeError occurs