### PR TITLE
ERC / Risk Parity Portfolio Weights

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1423,7 +1423,7 @@ def _erc_weights_ccd(x0,
     x = x0.copy()
     var = np.diagonal(cov)
     ctr = cov.dot(x)
-    sigma_x = x.T.dot(ctr)
+    sigma_x = np.sqrt(x.T.dot(ctr))
 
     for iteration in range(maximum_iterations):
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,6 @@ import pandas as pd
 import numpy as np
 from numpy.testing import assert_almost_equal as aae
 
-
 df = pd.read_csv('tests/data/test_data.csv', index_col=0, parse_dates=True)
 ts = df['AAPL'][0:10]
 
@@ -224,6 +223,21 @@ def test_calc_mean_var_weights():
     aae(actual['AAPL'], 0.000, 3)
     aae(actual['MSFT'], 0.000, 3)
     aae(actual['C'], 1.000, 3)
+
+
+def test_calc_erc_weights():
+    prc = df.ix[0:11]
+    rets = prc.to_returns().dropna()
+    actual = ffn.core.calc_erc_weights(rets)
+
+    assert len(actual) == 3
+    assert 'AAPL' in actual
+    assert 'MSFT' in actual
+    assert 'C' in actual
+
+    aae(actual['AAPL'], 0.270, 3)
+    aae(actual['MSFT'], 0.374, 3)
+    aae(actual['C'], 0.356, 3)
 
 
 def test_calc_total_return():


### PR DESCRIPTION
Addition of calc_erc_weights() to calculate the portfolio weights which equate to having an equal risk contribution. The function is called in similar way to the existing calc_mean_var_weights() and calc_inv_vol_weights() and the test script has also been added.

The resulting portfolio is similar to a minimum variance portfolio subject to a diversification constraint on the weights of its components and its volatility is located between those of the minimum variance and equally-weighted portfolios (Maillard 2008).

The code draws heavily on examples and code provided in Roncalli (2013) and the solution uses a cyclical coordinate descent (CDD) algorithm described in detail in Griveau-Billion, 2013.

```python  
def calc_erc_weights(returns,
                     initial_weights=None,
                     risk_weights=None,
                     covar_method='ledoit-wolf',
                     risk_parity_method='ccd',
                     maximum_iterations=100,
                     tolerance=1E-8):
    """
    Calculates the equal risk contribution / risk parity weights given a DataFrame
    of returns.
    Args:
        * returns (DataFrame): Returns for multiple securities.
        * initial_weights (list): Starting asset weights [default inverse vol].
        * risk_weights (list): Risk target weights [default equal weight].
        * covar_method (str): Covariance matrix estimation method.
            Currently supported:
                - ledoit-wolf [default]
                - standard
        * risk_parity_method (str): Risk parity estimation method.
            Currently supported:
                - ccd (cyclical coordinate descent)[default]
        * maximum_iterations (int): Maximum iterations in iterative solutions.
        * tolerance (float): Tolerance level in iterative solutions.
    Returns:
        Series {col_name: weight}
    """
```
'ccd' is currently the only supported 'risk_parity_method' and other methods discussed in the paper ( e.g sqp, jacobi, newton, nesterov) clearly have benefits too.

I plan to use the function to add a class WeighERC(Algo) to [bt](https://github.com/FinQuest/bt) if the pull request is approved by @pmorissette.

References:
[Griveau-Billion, Théophile and Richard, Jean-Charles and Roncalli, Thierry,
A Fast Algorithm for Computing High-Dimensional Risk Parity Portfolios (2013).](https://ssrn.com/abstract=2325255)

[Maillard, Sébastien and Roncalli, Thierry and Teiletche, Jerome, On the Properties of Equally-Weighted Risk Contributions Portfolios (September 22, 2008).](https://ssrn.com/abstract=1271972)

[Roncalli, Thierry, Introduction to Risk Parity and Budgeting (June 1, 2013). Roncalli T. (2013), Introduction to Risk Parity and Budgeting, Chapman & Hall/CRC Financial Mathematics Series.](https://ssrn.com/abstract=2272973)

Cheers,

Tim
