### PR TITLE
REF: Use builtin any over not np.all

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1765,7 +1765,7 @@ def limit_weights(weights, limit=0.1):
     res[res > limit] = limit
     res[res < limit] = ok
 
-    if not np.all([x <= limit for x in res]):
+    if any(x > limit for x in res):
         return limit_weights(res, limit=limit)
 
     return res

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -308,29 +308,20 @@ def test_drop_duplicate_cols():
 def test_limit_weights():
     w = {'a': 0.3, 'b': 0.1,
          'c': 0.05, 'd': 0.05, 'e': 0.5}
-
+    actual_exp = {'a': 0.3, 'b': 0.2, 'c': 0.1,
+                  'd': 0.1, 'e': 0.3}
     actual = ffn.core.limit_weights(w, 0.3)
 
     assert actual.sum() == 1.0
+    for k in actual_exp:
+        assert actual[k] == actual_exp[k]
 
-    assert actual['a'] == 0.3
-    assert actual['b'] == 0.2
-    assert actual['c'] == 0.1
-    assert actual['d'] == 0.1
-    assert actual['e'] == 0.3
-
-    w = pd.Series({'a': 0.3, 'b': 0.1,
-                   'c': 0.05, 'd': 0.05, 'e': 0.5})
-
+    w = pd.Series(w)
     actual = ffn.core.limit_weights(w, 0.3)
 
     assert actual.sum() == 1.0
-
-    assert actual['a'] == 0.3
-    assert actual['b'] == 0.2
-    assert actual['c'] == 0.1
-    assert actual['d'] == 0.1
-    assert actual['e'] == 0.3
+    for k in actual_exp:
+        assert actual[k] == actual_exp[k]
 
     w = pd.Series({'a': 0.29, 'b': 0.1,
                    'c': 0.06, 'd': 0.05, 'e': 0.5})


### PR DESCRIPTION
`any(>limit)` is faster than `not np.all(<=limit)` -- 2x in smaller data, 5-10x in larger data. Although, not significant in larger scheme of things. Accept this change as you seem fit :-) And, test case has  been updated, to do same tests in lesser LOC.

```python

In [138]: res = pd.Series(np.random.rand(100))

In [139]: %timeit not np.all([x <= 0.3 for x in res])
10000 loops, best of 3: 55.4 µs per loop

In [140]: %timeit any(x > 0.3 for x in res)
10000 loops, best of 3: 29.4 µs per loop

In [141]: res = pd.Series(np.random.rand(10000))

In [142]: %timeit not np.all([x <= 0.3 for x in res])
1000 loops, best of 3: 1.5 ms per loop

In [143]: %timeit any(x > 0.3 for x in res)
10000 loops, best of 3: 198 µs per loop
```
  