### PR TITLE
Replace deprecated use of .ix with .iloc

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1064,7 +1064,7 @@ def rebase(prices, value=100):
         * value (number): starting value for all series.
 
     """
-    return prices / prices.ix[0] * value
+    return prices / prices.iloc[0] * value
 
 
 def calc_perf_stats(prices):
@@ -1190,7 +1190,7 @@ def drawdown_details(drawdown):
 
     for i in range(0, len(start)):
         dd = drawdown[start[i]:end[i]].min()
-        result.ix[i] = (start[i], end[i], (end[i] - start[i]).days, dd)
+        result.iloc[i] = (start[i], end[i], (end[i] - start[i]).days, dd)
 
     return result
 
@@ -1207,7 +1207,7 @@ def calc_cagr(prices):
     """
     start = prices.index[0]
     end = prices.index[-1]
-    return (prices.ix[-1] / prices.ix[0]) ** (1 / year_frac(start, end)) - 1
+    return (prices.iloc[-1] / prices.iloc[0]) ** (1 / year_frac(start, end)) - 1
 
 
 def calc_risk_return_ratio(returns):
@@ -1280,7 +1280,7 @@ def calc_total_return(prices):
 
     last / first - 1
     """
-    return (prices.ix[-1] / prices.ix[0]) - 1
+    return (prices.iloc[-1] / prices.iloc[0]) - 1
 
 
 def year_frac(start, end):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -29,7 +29,7 @@ def test_to_returns_df():
     actual = data.to_returns()
 
     assert len(actual) == len(data)
-    assert all(np.isnan(actual.ix[0]))
+    assert all(np.isnan(actual.iloc[0]))
     aae(actual['AAPL'][1], -0.019, 3)
     aae(actual['AAPL'][9], -0.022, 3)
     aae(actual['MSFT'][1], -0.011, 3)
@@ -53,7 +53,7 @@ def test_to_log_returns_df():
     actual = data.to_log_returns()
 
     assert len(actual) == len(data)
-    assert all(np.isnan(actual.ix[0]))
+    assert all(np.isnan(actual.iloc[0]))
     aae(actual['AAPL'][1], -0.019, 3)
     aae(actual['AAPL'][9], -0.022, 3)
     aae(actual['MSFT'][1], -0.011, 3)
@@ -203,7 +203,7 @@ def test_merge():
 
 
 def test_calc_inv_vol_weights():
-    prc = df.ix[0:11]
+    prc = df.iloc[0:11]
     rets = prc.to_returns().dropna()
     actual = ffn.core.calc_inv_vol_weights(rets)
 
@@ -218,7 +218,7 @@ def test_calc_inv_vol_weights():
 
 
 def test_calc_mean_var_weights():
-    prc = df.ix[0:11]
+    prc = df.iloc[0:11]
     rets = prc.to_returns().dropna()
     actual = ffn.core.calc_mean_var_weights(rets)
 
@@ -233,7 +233,7 @@ def test_calc_mean_var_weights():
 
 
 def test_calc_erc_weights():
-    prc = df.ix[0:11]
+    prc = df.iloc[0:11]
     rets = prc.to_returns().dropna()
     actual = ffn.core.calc_erc_weights(rets)
 
@@ -248,7 +248,7 @@ def test_calc_erc_weights():
 
 
 def test_calc_total_return():
-    prc = df.ix[0:11]
+    prc = df.iloc[0:11]
     actual = prc.calc_total_return()
 
     assert len(actual) == 3


### PR DESCRIPTION
Replaced all occurrences of the deprecated .ix usages where it is clear that .iloc can be used instead.
.iloc should also be faster than .ix