### PR TITLE
Update calc_ftca method to use Series.sort_values

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1745,7 +1745,7 @@ def calc_ftca(returns, threshold=0.5):
             # filter down correlation matrix to current remain
             cur_corr = corr[remain].ix[remain]
             # get mean correlations, ordered
-            mc = cur_corr.mean().order()
+            mc = cur_corr.mean().sort_values()
             # get lowest and highest mean correlation
             low = mc.index[0]
             high = mc.index[-1]


### PR DESCRIPTION
In the latest version of Pandas, Series objects don't have the order method anymore. The method sort_values was introduced in Pandas 0.17.0

Fixes #46 