### PR TITLE
update documentation of argument risk_parity_method

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1642,6 +1642,7 @@ def calc_erc_weights(returns,
         * risk_parity_method (str): Risk parity estimation method.
             Currently supported:
                 - ccd (cyclical coordinate descent)[default]
+                - slsqp (scipy's implementation of sequential least squares programming)
         * maximum_iterations (int): Maximum iterations in iterative solutions.
         * tolerance (float): Tolerance level in iterative solutions.
 


### PR DESCRIPTION
This PR updates the documentation of the supported methods for risk parity computation.