### PR TITLE
Compatibility with matplotlib > 3.2.1

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -24,7 +24,7 @@ import os
 import matplotlib
 
 if 'DISPLAY' not in os.environ:
-    matplotlib.use('agg', warn=False)
+    matplotlib.use('agg')
 
 from matplotlib import pyplot as plt  # noqa
 


### PR DESCRIPTION
look at the documentation (https://matplotlib.org/3.2.1/api/matplotlib_configuration_api.html#matplotlib.use)

It seems to me that you are passing a parameter (warn) that has been deprecated