### PR TITLE
Remove Python 2 syntax from docs

### DIFF
--- a/docs/source/quickstart.ipynb
+++ b/docs/source/quickstart.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,28 +27,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "              agg    hyg     spy    eem    efa\n",
-      "Date                                          \n",
-      "2010-01-04  90.45  64.87  103.44  39.32  49.08\n",
-      "2010-01-05  90.86  65.18  103.71  39.61  49.13\n",
-      "2010-01-06  90.81  65.35  103.79  39.69  49.33\n",
-      "2010-01-07  90.70  65.61  104.23  39.46  49.14\n",
-      "2010-01-08  90.75  65.72  104.57  39.77  49.53\n",
-      "\n",
-      "[5 rows x 5 columns]\n"
+      "                  agg        hyg        spy        eem        efa\n",
+      "Date                                                             \n",
+      "2010-01-04  76.880875  46.122734  91.475693  34.109280  41.033138\n",
+      "2010-01-05  77.230598  46.341541  91.717857  34.356842  41.069305\n",
+      "2010-01-06  77.185966  46.461365  91.782425  34.428719  41.242893\n",
+      "2010-01-07  77.096664  46.648941  92.169884  34.229061  41.083767\n",
+      "2010-01-08  77.141350  46.721859  92.476562  34.500587  41.409260\n"
      ]
     }
    ],
    "source": [
     "data = ffn.get('agg,hyg,spy,eem,efa', start='2010-01-01', end='2014-01-01')\n",
-    "print data.head()"
+    "data.head()"
    ]
   },
   {
@@ -60,27 +58,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "            aaplopen  aaplhigh  aapllow  aaplclose\n",
-      "Date                                              \n",
-      "2010-01-04    213.43    214.50   212.38     214.01\n",
-      "2010-01-05    214.60    215.59   213.25     214.38\n",
-      "2010-01-06    214.38    215.23   210.75     210.97\n",
-      "2010-01-07    211.75    212.00   209.05     210.58\n",
-      "2010-01-08    210.30    212.00   209.06     211.98\n",
-      "\n",
-      "[5 rows x 4 columns]\n"
+      "            aaplopen  aaplhigh   aapllow  aaplclose\n",
+      "Date                                               \n",
+      "2010-01-04  7.622500  7.660714  7.585000   7.643214\n",
+      "2010-01-05  7.664286  7.699643  7.616071   7.656428\n",
+      "2010-01-06  7.656428  7.686786  7.526786   7.534643\n",
+      "2010-01-07  7.562500  7.571429  7.466072   7.520714\n",
+      "2010-01-08  7.510714  7.571429  7.466429   7.570714\n"
      ]
     }
    ],
    "source": [
-    "print ffn.get('aapl:Open,aapl:High,aapl:Low,aapl:Close', start='2010-01-01', end='2014-01-01').head()"
+    "ffn.get('aapl:Open,aapl:High,aapl:Low,aapl:Close', start='2010-01-01', end='2014-01-01').head()"
    ]
   },
   {
@@ -114,7 +110,7 @@
    ],
    "source": [
     "data = ffn.get('dbc', provider=ffn.data.csv, path='test_data.csv', existing=data)\n",
-    "print data.head()"
+    "data.head()"
    ]
   },
   {
@@ -153,7 +149,7 @@
    ],
    "source": [
     "returns = data.to_log_returns().dropna()\n",
-    "print returns.head()"
+    "returns.head()"
    ]
   },
   {
@@ -467,7 +463,7 @@
     }
    ],
    "source": [
-    "print perf.display()"
+    "perf.display()"
    ]
   },
   {
@@ -664,9 +660,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR simply removes the `print` statements from the Quickstart page the docs. This removes the Python 2 syntax, and I thought it would be more appropriate for a Jupyter notebook.