### PR TITLE
Update ytd and mtd calculation

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -334,7 +334,7 @@ class PerformanceStats(object):
             if len(mr) < 3:
                 return
 
-            denom = dp[:dp.index[-1] - pd.DateOffset(months=3)]
+            denom = dp[: dp.index[-1] - pd.DateOffset(months=3)]
             if len(denom) > 0:
                 self.three_month = dp[-1] / denom[-1] - 1
 
@@ -352,7 +352,7 @@ class PerformanceStats(object):
             if len(mr) < 6:
                 return
 
-            denom = dp[:dp.index[-1] - pd.DateOffset(months=6)]
+            denom = dp[: dp.index[-1] - pd.DateOffset(months=6)]
 
             if len(denom) > 0:
                 self.six_month = dp[-1] / denom[-1] - 1
@@ -366,7 +366,7 @@ class PerformanceStats(object):
             if len(yr) < 2:
                 return
 
-            denom = dp[:dp.index[-1] - pd.DateOffset(years=1)]
+            denom = dp[: dp.index[-1] - pd.DateOffset(years=1)]
 
             if len(denom) > 0:
                 self.one_year = dp[-1] / denom[-1] - 1

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -411,7 +411,7 @@ class PerformanceStats(object):
                 return
 
             # annualize stat for over 1 year
-            self.three_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=3):])
+            self.three_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=3) :])
 
         if r.index.to_series().diff().min() < pd.Timedelta("367 days"):
             if len(yr) < 4:
@@ -426,12 +426,12 @@ class PerformanceStats(object):
         if r.index.to_series().diff().min() < pd.Timedelta("1828 days"):
             if len(yr) < 5:
                 return
-            self.five_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=5):])
+            self.five_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=5) :])
 
         if r.index.to_series().diff().min() < pd.Timedelta("3654 days"):
             if len(yr) < 10:
                 return
-            self.ten_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=10):])
+            self.ten_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=10) :])
 
         return
 
@@ -1351,7 +1351,7 @@ def drawdown_details(drawdown, index_type=pd.DatetimeIndex):
     )
 
     for i in range(0, len(start)):
-        dd = drawdown[start[i]:end[i]].min()
+        dd = drawdown[start[i] : end[i]].min()
 
         if index_type is pd.DatetimeIndex:
             result.iloc[i] = (start[i], end[i], (end[i] - start[i]).days, dd)

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -208,10 +208,10 @@ class PerformanceStats(object):
 
         if len(dp) == 1:
             return
-        
+
         self.mtd = calc_mtd(dp, mp)
         self.ytd = calc_ytd(dp, yp)
-        
+
         # stats using daily data
         self.returns = dp.to_returns()
         self.log_returns = dp.to_log_returns()
@@ -353,7 +353,7 @@ class PerformanceStats(object):
                 return
 
             denom = dp[:dp.index[-1] - pd.DateOffset(months=6)]
-            
+
             if len(denom) > 0:
                 self.six_month = dp[-1] / denom[-1] - 1
 
@@ -411,7 +411,7 @@ class PerformanceStats(object):
                 return
 
             # annualize stat for over 1 year
-            self.three_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=3) :])
+            self.three_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=3):])
 
         if r.index.to_series().diff().min() < pd.Timedelta("367 days"):
             if len(yr) < 4:
@@ -426,12 +426,12 @@ class PerformanceStats(object):
         if r.index.to_series().diff().min() < pd.Timedelta("1828 days"):
             if len(yr) < 5:
                 return
-            self.five_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=5) :])
+            self.five_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=5):])
 
         if r.index.to_series().diff().min() < pd.Timedelta("3654 days"):
             if len(yr) < 10:
                 return
-            self.ten_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=10) :])
+            self.ten_year = calc_cagr(dp[dp.index[-1] - pd.DateOffset(years=10):])
 
         return
 
@@ -1272,11 +1272,11 @@ def to_drawdown_series(prices):
 def calc_mtd(daily_prices, monthly_prices):
     """
     Calculates mtd return of a price series.
-    Use daily_prices if prices are only available from same month, 
+    Use daily_prices if prices are only available from same month
     else use monthly_prices
     """
     if len(monthly_prices) == 1:
-        return daily_prices[-1] / daily_prices[0] - 1        
+        return daily_prices[-1] / daily_prices[0] - 1
     else:
         return daily_prices[-1] / monthly_prices[-2] - 1
 
@@ -1284,11 +1284,11 @@ def calc_mtd(daily_prices, monthly_prices):
 def calc_ytd(daily_prices, yearly_prices):
     """
     Calculates ytd return of a price series.
-    Use daily_prices if prices are only available from same year, 
+    Use daily_prices if prices are only available from same year
     else use yearly_prices
     """
     if len(yearly_prices) == 1:
-        return daily_prices[-1] / daily_prices[0] - 1        
+        return daily_prices[-1] / daily_prices[0] - 1
     else:
         return daily_prices[-1] / yearly_prices[-2] - 1
 
@@ -1351,7 +1351,7 @@ def drawdown_details(drawdown, index_type=pd.DatetimeIndex):
     )
 
     for i in range(0, len(start)):
-        dd = drawdown[start[i] : end[i]].min()
+        dd = drawdown[start[i]:end[i]].min()
 
         if index_type is pd.DatetimeIndex:
             result.iloc[i] = (start[i], end[i], (end[i] - start[i]).days, dd)

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -209,17 +209,8 @@ class PerformanceStats(object):
         if len(dp) == 1:
             return
         
-        # Use dp if returns are only available from same month, else mp[-2]
-        if len(mp) == 1:
-            self.mtd = dp[-1] / dp[0] - 1        
-        else:
-            self.mtd = dp[-1] / mp[-2] - 1
-        
-        # Use dp if returns are only avaliable from same year, else yp[-2]
-        if len(yp) == 1:
-            self.ytd = dp[-1] / dp[0] - 1
-        else:
-            self.ytd = dp[-1] / yp[-2] - 1
+        self.mtd = calc_mtd(dp, mp)
+        self.ytd = calc_ytd(dp, yp)
         
         # stats using daily data
         self.returns = dp.to_returns()
@@ -343,7 +334,7 @@ class PerformanceStats(object):
             if len(mr) < 3:
                 return
 
-            denom = dp[: dp.index[-1] - pd.DateOffset(months=3)]
+            denom = dp[:dp.index[-1] - pd.DateOffset(months=3)]
             if len(denom) > 0:
                 self.three_month = dp[-1] / denom[-1] - 1
 
@@ -361,7 +352,8 @@ class PerformanceStats(object):
             if len(mr) < 6:
                 return
 
-            denom = dp[: dp.index[-1] - pd.DateOffset(months=6)]
+            denom = dp[:dp.index[-1] - pd.DateOffset(months=6)]
+            
             if len(denom) > 0:
                 self.six_month = dp[-1] / denom[-1] - 1
 
@@ -373,8 +365,6 @@ class PerformanceStats(object):
 
             if len(yr) < 2:
                 return
-
-            self.ytd = dp[-1] / yp[-2] - 1
 
             denom = dp[:dp.index[-1] - pd.DateOffset(years=1)]
 
@@ -1277,6 +1267,30 @@ def to_drawdown_series(prices):
 
     drawdown = drawdown / roll_max - 1.0
     return drawdown
+
+
+def calc_mtd(daily_prices, monthly_prices):
+    """
+    Calculates mtd return of a price series.
+    Use daily_prices if prices are only available from same month, 
+    else use monthly_prices
+    """
+    if len(monthly_prices) == 1:
+        return daily_prices[-1] / daily_prices[0] - 1        
+    else:
+        return daily_prices[-1] / monthly_prices[-2] - 1
+
+
+def calc_ytd(daily_prices, yearly_prices):
+    """
+    Calculates ytd return of a price series.
+    Use daily_prices if prices are only available from same year, 
+    else use yearly_prices
+    """
+    if len(yearly_prices) == 1:
+        return daily_prices[-1] / daily_prices[0] - 1        
+    else:
+        return daily_prices[-1] / yearly_prices[-2] - 1
 
 
 def calc_max_drawdown(prices):

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -183,7 +183,19 @@ class PerformanceStats(object):
 
         if len(dp) is 1:
             return
-
+        
+        # Use dp if returns are only available from same month, else mp[-2]
+        if len(mp) == 1:
+            self.mtd = dp[-1] / dp[0] - 1        
+        else:
+            self.mtd = dp[-1] / mp[-2] - 1
+        
+        # Use dp if returns are only avaliable from same year, else yp[-2]
+        if len(yp) == 1:
+            self.ytd = dp[-1] / dp[0] - 1
+        else:
+            self.ytd = dp[-1] / yp[-2] - 1
+        
         # stats using daily data
         self.returns = dp.to_returns()
         self.log_returns = dp.to_log_returns()
@@ -211,9 +223,7 @@ class PerformanceStats(object):
             self.worst_day = r.min()
 
         self.total_return = obj[-1] / obj[0] - 1
-        # save ytd as total_return for now - if we get to real ytd
-        # then it will get updated
-        self.ytd = self.total_return
+
         self.cagr = calc_cagr(dp)
         self.incep = self.cagr
 
@@ -259,9 +269,6 @@ class PerformanceStats(object):
                 self.monthly_sortino = calc_sortino_ratio(mr, rf=_rf_monthly_price_returns, nperiods=12)
             self.best_month = mr.max()
             self.worst_month = mr.min()
-
-            # -2 because p[-1] will be mp[-1]
-            self.mtd = dp[-1] / mp[-2] - 1
 
             # -1 here to account for first return that will be nan
             self.pos_month_perc = len(mr[mr > 0]) / float(len(mr) - 1)
@@ -322,8 +329,6 @@ class PerformanceStats(object):
 
             if len(yr) < 2:
                 return
-
-            self.ytd = dp[-1] / yp[-2] - 1
 
             denom = dp[:dp.index[-1] - pd.DateOffset(years=1)]
             if len(denom) > 0:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,24 +4,24 @@ import numpy as np
 from numpy.testing import assert_almost_equal as aae
 
 try:
-    df = pd.read_csv('tests/data/test_data.csv', index_col=0, parse_dates=True)
+    df = pd.read_csv("tests/data/test_data.csv", index_col=0, parse_dates=True)
 except FileNotFoundError as e:
     try:
-        df = pd.read_csv('data/test_data.csv', index_col=0, parse_dates=True)
+        df = pd.read_csv("data/test_data.csv", index_col=0, parse_dates=True)
     except FileNotFoundError as e2:
-        raise(str(e2))
+        raise (str(e2))
 
-ts = df['AAPL'][0:10]
+ts = df["AAPL"][0:10]
 
 
 def test_mtd_ytd():
-    data = df['AAPL']
+    data = df["AAPL"]
 
     # Intramonth
-    prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2004-12-25')]
-    dp = prices.resample('D').last().dropna()
-    mp = prices.resample('M').last().dropna()
-    yp = prices.resample('A').last().dropna()
+    prices = data[pd.to_datetime("2004-12-10") : pd.to_datetime("2004-12-25")]
+    dp = prices.resample("D").last().dropna()
+    mp = prices.resample("M").last().dropna()
+    yp = prices.resample("A").last().dropna()
     mtd_actual = ffn.calc_mtd(dp, mp)
     ytd_actual = ffn.calc_ytd(dp, yp)
 
@@ -29,10 +29,10 @@ def test_mtd_ytd():
     assert mtd_actual == ytd_actual
 
     # Year change - first month
-    prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2005-01-15')]
-    dp = prices.resample('D').last().dropna()
-    mp = prices.resample('M').last().dropna()
-    yp = prices.resample('A').last().dropna()
+    prices = data[pd.to_datetime("2004-12-10") : pd.to_datetime("2005-01-15")]
+    dp = prices.resample("D").last().dropna()
+    mp = prices.resample("M").last().dropna()
+    yp = prices.resample("A").last().dropna()
     mtd_actual = ffn.calc_mtd(dp, mp)
     ytd_actual = ffn.calc_ytd(dp, yp)
 
@@ -40,10 +40,10 @@ def test_mtd_ytd():
     assert mtd_actual == ytd_actual
 
     # Year change - second month
-    prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2005-02-15')]
-    dp = prices.resample('D').last().dropna()
-    mp = prices.resample('M').last().dropna()
-    yp = prices.resample('A').last().dropna()
+    prices = data[pd.to_datetime("2004-12-10") : pd.to_datetime("2005-02-15")]
+    dp = prices.resample("D").last().dropna()
+    mp = prices.resample("M").last().dropna()
+    yp = prices.resample("A").last().dropna()
     mtd_actual = ffn.calc_mtd(dp, mp)
     ytd_actual = ffn.calc_ytd(dp, yp)
 
@@ -51,10 +51,10 @@ def test_mtd_ytd():
     aae(ytd_actual, 0.3728, 4)
 
     # Single day
-    prices = data[[pd.to_datetime('2004-12-10')]]
-    dp = prices.resample('D').last().dropna()
-    mp = prices.resample('M').last().dropna()
-    yp = prices.resample('A').last().dropna()
+    prices = data[[pd.to_datetime("2004-12-10")]]
+    dp = prices.resample("D").last().dropna()
+    mp = prices.resample("M").last().dropna()
+    yp = prices.resample("A").last().dropna()
     mtd_actual = ffn.calc_mtd(dp, mp)
     ytd_actual = ffn.calc_ytd(dp, yp)
 
@@ -77,12 +77,12 @@ def test_to_returns_df():
 
     assert len(actual) == len(data)
     assert all(np.isnan(actual.iloc[0]))
-    aae(actual['AAPL'][1], -0.019, 3)
-    aae(actual['AAPL'][9], -0.022, 3)
-    aae(actual['MSFT'][1], -0.011, 3)
-    aae(actual['MSFT'][9], -0.014, 3)
-    aae(actual['C'][1], -0.012, 3)
-    aae(actual['C'][9], 0.004, 3)
+    aae(actual["AAPL"][1], -0.019, 3)
+    aae(actual["AAPL"][9], -0.022, 3)
+    aae(actual["MSFT"][1], -0.011, 3)
+    aae(actual["MSFT"][9], -0.014, 3)
+    aae(actual["C"][1], -0.012, 3)
+    aae(actual["C"][9], 0.004, 3)
 
 
 def test_to_log_returns_ts():
@@ -101,12 +101,12 @@ def test_to_log_returns_df():
 
     assert len(actual) == len(data)
     assert all(np.isnan(actual.iloc[0]))
-    aae(actual['AAPL'][1], -0.019, 3)
-    aae(actual['AAPL'][9], -0.022, 3)
-    aae(actual['MSFT'][1], -0.011, 3)
-    aae(actual['MSFT'][9], -0.014, 3)
-    aae(actual['C'][1], -0.012, 3)
-    aae(actual['C'][9], 0.004, 3)
+    aae(actual["AAPL"][1], -0.019, 3)
+    aae(actual["AAPL"][9], -0.022, 3)
+    aae(actual["MSFT"][1], -0.011, 3)
+    aae(actual["MSFT"][9], -0.014, 3)
+    aae(actual["C"][1], -0.012, 3)
+    aae(actual["C"][9], 0.004, 3)
 
 
 def test_to_price_index():
@@ -115,22 +115,22 @@ def test_to_price_index():
     actual = rets.to_price_index()
 
     assert len(actual) == len(data)
-    aae(actual['AAPL'][0], 100, 3)
-    aae(actual['MSFT'][0], 100, 3)
-    aae(actual['C'][0], 100, 3)
-    aae(actual['AAPL'][9], 91.366, 3)
-    aae(actual['MSFT'][9], 95.191, 3)
-    aae(actual['C'][9], 101.199, 3)
+    aae(actual["AAPL"][0], 100, 3)
+    aae(actual["MSFT"][0], 100, 3)
+    aae(actual["C"][0], 100, 3)
+    aae(actual["AAPL"][9], 91.366, 3)
+    aae(actual["MSFT"][9], 95.191, 3)
+    aae(actual["C"][9], 101.199, 3)
 
     actual = rets.to_price_index(start=1)
 
     assert len(actual) == len(data)
-    aae(actual['AAPL'][0], 1, 3)
-    aae(actual['MSFT'][0], 1, 3)
-    aae(actual['C'][0], 1, 3)
-    aae(actual['AAPL'][9], 0.914, 3)
-    aae(actual['MSFT'][9], 0.952, 3)
-    aae(actual['C'][9], 1.012, 3)
+    aae(actual["AAPL"][0], 1, 3)
+    aae(actual["MSFT"][0], 1, 3)
+    aae(actual["C"][0], 1, 3)
+    aae(actual["AAPL"][9], 0.914, 3)
+    aae(actual["MSFT"][9], 0.952, 3)
+    aae(actual["C"][9], 1.012, 3)
 
 
 def test_rebase():
@@ -138,12 +138,12 @@ def test_rebase():
     actual = data.rebase()
 
     assert len(actual) == len(data)
-    aae(actual['AAPL'][0], 100, 3)
-    aae(actual['MSFT'][0], 100, 3)
-    aae(actual['C'][0], 100, 3)
-    aae(actual['AAPL'][9], 91.366, 3)
-    aae(actual['MSFT'][9], 95.191, 3)
-    aae(actual['C'][9], 101.199, 3)
+    aae(actual["AAPL"][0], 100, 3)
+    aae(actual["MSFT"][0], 100, 3)
+    aae(actual["C"][0], 100, 3)
+    aae(actual["AAPL"][9], 91.366, 3)
+    aae(actual["MSFT"][9], 95.191, 3)
+    aae(actual["C"][9], 101.199, 3)
 
 
 def test_to_drawdown_series_ts():
@@ -161,17 +161,17 @@ def test_to_drawdown_series_df():
     actual = data.to_drawdown_series()
 
     assert len(actual) == len(data)
-    aae(actual['AAPL'][0], 0, 3)
-    aae(actual['MSFT'][0], 0, 3)
-    aae(actual['C'][0], 0, 3)
+    aae(actual["AAPL"][0], 0, 3)
+    aae(actual["MSFT"][0], 0, 3)
+    aae(actual["C"][0], 0, 3)
 
-    aae(actual['AAPL'][1], -0.019, 3)
-    aae(actual['MSFT'][1], -0.011, 3)
-    aae(actual['C'][1], -0.012, 3)
+    aae(actual["AAPL"][1], -0.019, 3)
+    aae(actual["MSFT"][1], -0.011, 3)
+    aae(actual["C"][1], -0.012, 3)
 
-    aae(actual['AAPL'][9], -0.086, 3)
-    aae(actual['MSFT'][9], -0.048, 3)
-    aae(actual['C'][9], -0.029, 3)
+    aae(actual["AAPL"][9], -0.086, 3)
+    aae(actual["MSFT"][9], -0.048, 3)
+    aae(actual["C"][9], -0.029, 3)
 
 
 def test_max_drawdown_ts():
@@ -186,14 +186,13 @@ def test_max_drawdown_df():
     data = data[0:10]
     actual = data.calc_max_drawdown()
 
-    aae(actual['AAPL'], -0.086, 3)
-    aae(actual['MSFT'], -0.048, 3)
-    aae(actual['C'], -0.033, 3)
+    aae(actual["AAPL"], -0.086, 3)
+    aae(actual["MSFT"], -0.048, 3)
+    aae(actual["C"], -0.033, 3)
 
 
 def test_year_frac():
-    actual = ffn.year_frac(pd.to_datetime('2004-03-10'),
-                           pd.to_datetime('2004-03-29'))
+    actual = ffn.year_frac(pd.to_datetime("2004-03-10"), pd.to_datetime("2004-03-29"))
     # not exactly the same as excel but close enough
     aae(actual, 0.0520, 4)
 
@@ -207,46 +206,44 @@ def test_cagr_ts():
 def test_cagr_df():
     data = df
     actual = data.calc_cagr()
-    aae(actual['AAPL'], 0.440, 3)
-    aae(actual['MSFT'], 0.041, 3)
-    aae(actual['C'], -0.205, 3)
+    aae(actual["AAPL"], 0.440, 3)
+    aae(actual["MSFT"], 0.041, 3)
+    aae(actual["C"], -0.205, 3)
 
 
 def test_merge():
-    a = pd.Series(index=pd.date_range('2010-01-01', periods=5),
-                  data=100, name='a')
-    b = pd.Series(index=pd.date_range('2010-01-02', periods=5),
-                  data=200, name='b')
+    a = pd.Series(index=pd.date_range("2010-01-01", periods=5), data=100, name="a")
+    b = pd.Series(index=pd.date_range("2010-01-02", periods=5), data=200, name="b")
     actual = ffn.merge(a, b)
 
-    assert 'a' in actual
-    assert 'b' in actual
+    assert "a" in actual
+    assert "b" in actual
     assert len(actual) == 6
     assert len(actual.columns) == 2
-    assert np.isnan(actual['a'][-1])
-    assert np.isnan(actual['b'][0])
-    assert actual['a'][0] == 100
-    assert actual['a'][1] == 100
-    assert actual['b'][-1] == 200
-    assert actual['b'][1] == 200
+    assert np.isnan(actual["a"][-1])
+    assert np.isnan(actual["b"][0])
+    assert actual["a"][0] == 100
+    assert actual["a"][1] == 100
+    assert actual["b"][-1] == 200
+    assert actual["b"][1] == 200
 
     old = actual
-    old.columns = ['c', 'd']
+    old.columns = ["c", "d"]
 
     actual = ffn.merge(old, a, b)
 
-    assert 'a' in actual
-    assert 'b' in actual
-    assert 'c' in actual
-    assert 'd' in actual
+    assert "a" in actual
+    assert "b" in actual
+    assert "c" in actual
+    assert "d" in actual
     assert len(actual) == 6
     assert len(actual.columns) == 4
-    assert np.isnan(actual['a'][-1])
-    assert np.isnan(actual['b'][0])
-    assert actual['a'][0] == 100
-    assert actual['a'][1] == 100
-    assert actual['b'][-1] == 200
-    assert actual['b'][1] == 200
+    assert np.isnan(actual["a"][-1])
+    assert np.isnan(actual["b"][0])
+    assert actual["a"][0] == 100
+    assert actual["a"][1] == 100
+    assert actual["b"][-1] == 200
+    assert actual["b"][1] == 200
 
 
 def test_calc_inv_vol_weights():
@@ -255,13 +252,13 @@ def test_calc_inv_vol_weights():
     actual = ffn.core.calc_inv_vol_weights(rets)
 
     assert len(actual) == 3
-    assert 'AAPL' in actual
-    assert 'MSFT' in actual
-    assert 'C' in actual
+    assert "AAPL" in actual
+    assert "MSFT" in actual
+    assert "C" in actual
 
-    aae(actual['AAPL'], 0.218, 3)
-    aae(actual['MSFT'], 0.464, 3)
-    aae(actual['C'], 0.318, 3)
+    aae(actual["AAPL"], 0.218, 3)
+    aae(actual["MSFT"], 0.464, 3)
+    aae(actual["C"], 0.318, 3)
 
 
 def test_calc_mean_var_weights():
@@ -270,13 +267,13 @@ def test_calc_mean_var_weights():
     actual = ffn.core.calc_mean_var_weights(rets)
 
     assert len(actual) == 3
-    assert 'AAPL' in actual
-    assert 'MSFT' in actual
-    assert 'C' in actual
+    assert "AAPL" in actual
+    assert "MSFT" in actual
+    assert "C" in actual
 
-    aae(actual['AAPL'], 0.000, 3)
-    aae(actual['MSFT'], 0.000, 3)
-    aae(actual['C'], 1.000, 3)
+    aae(actual["AAPL"], 0.000, 3)
+    aae(actual["MSFT"], 0.000, 3)
+    aae(actual["C"], 1.000, 3)
 
 
 def test_calc_erc_weights():
@@ -286,61 +283,52 @@ def test_calc_erc_weights():
     actual = ffn.core.calc_erc_weights(rets)
 
     assert len(actual) == 3
-    assert 'AAPL' in actual
-    assert 'MSFT' in actual
-    assert 'C' in actual
+    assert "AAPL" in actual
+    assert "MSFT" in actual
+    assert "C" in actual
 
-    aae(actual['AAPL'], 0.270, 3)
-    aae(actual['MSFT'], 0.374, 3)
-    aae(actual['C'], 0.356, 3)
+    aae(actual["AAPL"], 0.270, 3)
+    aae(actual["MSFT"], 0.374, 3)
+    aae(actual["C"], 0.356, 3)
 
     actual = ffn.core.calc_erc_weights(
-        rets,
-        covar_method='ledoit-wolf',
-        risk_parity_method='slsqp',
-        tolerance=1e-9
+        rets, covar_method="ledoit-wolf", risk_parity_method="slsqp", tolerance=1e-9
     )
 
     assert len(actual) == 3
-    assert 'AAPL' in actual
-    assert 'MSFT' in actual
-    assert 'C' in actual
+    assert "AAPL" in actual
+    assert "MSFT" in actual
+    assert "C" in actual
 
-    aae(actual['AAPL'], 0.270, 3)
-    aae(actual['MSFT'], 0.374, 3)
-    aae(actual['C'], 0.356, 3)
+    aae(actual["AAPL"], 0.270, 3)
+    aae(actual["MSFT"], 0.374, 3)
+    aae(actual["C"], 0.356, 3)
 
     actual = ffn.core.calc_erc_weights(
-        rets,
-        covar_method='standard',
-        risk_parity_method='ccd',
-        tolerance=1e-9
+        rets, covar_method="standard", risk_parity_method="ccd", tolerance=1e-9
     )
 
     assert len(actual) == 3
-    assert 'AAPL' in actual
-    assert 'MSFT' in actual
-    assert 'C' in actual
+    assert "AAPL" in actual
+    assert "MSFT" in actual
+    assert "C" in actual
 
-    aae(actual['AAPL'], 0.234, 3)
-    aae(actual['MSFT'], 0.409, 3)
-    aae(actual['C'], 0.356, 3)
+    aae(actual["AAPL"], 0.234, 3)
+    aae(actual["MSFT"], 0.409, 3)
+    aae(actual["C"], 0.356, 3)
 
     actual = ffn.core.calc_erc_weights(
-        rets,
-        covar_method='standard',
-        risk_parity_method='slsqp',
-        tolerance=1e-9
+        rets, covar_method="standard", risk_parity_method="slsqp", tolerance=1e-9
     )
 
     assert len(actual) == 3
-    assert 'AAPL' in actual
-    assert 'MSFT' in actual
-    assert 'C' in actual
+    assert "AAPL" in actual
+    assert "MSFT" in actual
+    assert "C" in actual
 
-    aae(actual['AAPL'], 0.234, 3)
-    aae(actual['MSFT'], 0.409, 3)
-    aae(actual['C'], 0.356, 3)
+    aae(actual["AAPL"], 0.234, 3)
+    aae(actual["MSFT"], 0.409, 3)
+    aae(actual["C"], 0.356, 3)
 
 
 def test_calc_total_return():
@@ -348,71 +336,65 @@ def test_calc_total_return():
     actual = prc.calc_total_return()
 
     assert len(actual) == 3
-    aae(actual['AAPL'], -0.079, 3)
-    aae(actual['MSFT'], -0.038, 3)
-    aae(actual['C'], 0.012, 3)
+    aae(actual["AAPL"], -0.079, 3)
+    aae(actual["MSFT"], -0.038, 3)
+    aae(actual["C"], 0.012, 3)
 
 
 def test_get_num_days_required():
-    actual = ffn.core.get_num_days_required(pd.DateOffset(months=3),
-                                            perc_required=1.)
+    actual = ffn.core.get_num_days_required(pd.DateOffset(months=3), perc_required=1.0)
     assert actual >= 60
 
-    actual = ffn.core.get_num_days_required(pd.DateOffset(months=3),
-                                            perc_required=1.,
-                                            period='m')
+    actual = ffn.core.get_num_days_required(
+        pd.DateOffset(months=3), perc_required=1.0, period="m"
+    )
     assert actual >= 3
 
 
 def test_asfreq_actual():
-    a = pd.Series({pd.to_datetime('2010-02-27'): 100,
-                   pd.to_datetime('2010-03-25'): 200})
-    actual = a.asfreq_actual(freq='M', method='ffill')
+    a = pd.Series(
+        {pd.to_datetime("2010-02-27"): 100, pd.to_datetime("2010-03-25"): 200}
+    )
+    actual = a.asfreq_actual(freq="M", method="ffill")
 
     assert len(actual) == 1
-    assert '2010-02-27' in actual
+    assert "2010-02-27" in actual
 
 
 def test_to_monthly():
-    a = pd.Series(range(100), index=pd.date_range(
-        '2010-01-01', periods=100))
+    a = pd.Series(range(100), index=pd.date_range("2010-01-01", periods=100))
     # to test for actual dates
-    a['2010-01-31'] = np.nan
+    a["2010-01-31"] = np.nan
     a = a.dropna()
 
     actual = a.to_monthly()
 
     assert len(actual) == 3
-    assert '2010-01-30' in actual
-    assert actual['2010-01-30'] == 29
+    assert "2010-01-30" in actual
+    assert actual["2010-01-30"] == 29
 
 
 def test_drop_duplicate_cols():
-    a = pd.Series(index=pd.date_range('2010-01-01', periods=5),
-                  data=100, name='a')
+    a = pd.Series(index=pd.date_range("2010-01-01", periods=5), data=100, name="a")
     # second version of a w/ less data
-    a2 = pd.Series(index=pd.date_range('2010-01-02', periods=4),
-                   data=900, name='a')
-    b = pd.Series(index=pd.date_range('2010-01-02', periods=5),
-                  data=200, name='b')
+    a2 = pd.Series(index=pd.date_range("2010-01-02", periods=4), data=900, name="a")
+    b = pd.Series(index=pd.date_range("2010-01-02", periods=5), data=200, name="b")
     actual = ffn.merge(a, a2, b)
 
-    assert actual['a'].shape[1] == 2
+    assert actual["a"].shape[1] == 2
     assert len(actual.columns) == 3
 
     actual = actual.drop_duplicate_cols()
 
     assert len(actual.columns) == 2
-    assert 'a' in actual
-    assert 'b' in actual
-    assert len(actual['a'].dropna()) == 5
+    assert "a" in actual
+    assert "b" in actual
+    assert len(actual["a"].dropna()) == 5
 
 
 def test_limit_weights():
-    w = {'a': 0.3, 'b': 0.1,
-         'c': 0.05, 'd': 0.05, 'e': 0.5}
-    actual_exp = {'a': 0.3, 'b': 0.2, 'c': 0.1,
-                  'd': 0.1, 'e': 0.3}
+    w = {"a": 0.3, "b": 0.1, "c": 0.05, "d": 0.05, "e": 0.5}
+    actual_exp = {"a": 0.3, "b": 0.2, "c": 0.1, "d": 0.1, "e": 0.3}
     actual = ffn.core.limit_weights(w, 0.3)
 
     assert actual.sum() == 1.0
@@ -426,8 +408,7 @@ def test_limit_weights():
     for k in actual_exp:
         assert actual[k] == actual_exp[k]
 
-    w = pd.Series({'a': 0.29, 'b': 0.1,
-                   'c': 0.06, 'd': 0.05, 'e': 0.5})
+    w = pd.Series({"a": 0.29, "b": 0.1, "c": 0.06, "d": 0.05, "e": 0.5})
 
     assert w.sum() == 1.0
 
@@ -437,16 +418,16 @@ def test_limit_weights():
 
     assert all(x <= 0.3 for x in actual)
 
-    aae(actual['a'], 0.300, 3)
-    aae(actual['b'], 0.190, 3)
-    aae(actual['c'], 0.114, 3)
-    aae(actual['d'], 0.095, 3)
-    aae(actual['e'], 0.300, 3)
+    aae(actual["a"], 0.300, 3)
+    aae(actual["b"], 0.190, 3)
+    aae(actual["c"], 0.114, 3)
+    aae(actual["d"], 0.095, 3)
+    aae(actual["e"], 0.300, 3)
 
 
 def test_random_weights():
     n = 10
-    bounds = (0., 1.)
+    bounds = (0.0, 1.0)
     tot = 1.0000
     low = bounds[0]
     high = bounds[1]
@@ -458,7 +439,7 @@ def test_random_weights():
     assert df.applymap(lambda x: (x >= low and x <= high)).all().all()
 
     n = 4
-    bounds = (0., 0.25)
+    bounds = (0.0, 0.25)
     tot = 1.0000
     low = bounds[0]
     high = bounds[1]
@@ -467,12 +448,14 @@ def test_random_weights():
     for i in df.index:
         df.loc[i] = ffn.random_weights(n, bounds, tot)
     assert df.sum(axis=1).apply(lambda x: np.round(x, 4) == tot).all()
-    assert df.applymap(
-        lambda x: (np.round(x, 2) >= low and
-                   np.round(x, 2) <= high)).all().all()
+    assert (
+        df.applymap(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
+        .all()
+        .all()
+    )
 
     n = 7
-    bounds = (0., 0.25)
+    bounds = (0.0, 0.25)
     tot = 0.8000
     low = bounds[0]
     high = bounds[1]
@@ -481,12 +464,14 @@ def test_random_weights():
     for i in df.index:
         df.loc[i] = ffn.random_weights(n, bounds, tot)
     assert df.sum(axis=1).apply(lambda x: np.round(x, 4) == tot).all()
-    assert df.applymap(
-        lambda x: (np.round(x, 2) >= low and
-                   np.round(x, 2) <= high)).all().all()
+    assert (
+        df.applymap(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
+        .all()
+        .all()
+    )
 
     n = 10
-    bounds = (-.25, 0.25)
+    bounds = (-0.25, 0.25)
     tot = 0.0
     low = bounds[0]
     high = bounds[1]
@@ -495,14 +480,16 @@ def test_random_weights():
     for i in df.index:
         df.loc[i] = ffn.random_weights(n, bounds, tot)
     assert df.sum(axis=1).apply(lambda x: np.round(x, 4) == tot).all()
-    assert df.applymap(
-        lambda x: (np.round(x, 2) >= low and
-                   np.round(x, 2) <= high)).all().all()
+    assert (
+        df.applymap(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
+        .all()
+        .all()
+    )
 
 
 def test_random_weights_throws_error():
     try:
-        ffn.random_weights(2, (0., 0.25), 1.0)
+        ffn.random_weights(2, (0.0, 0.25), 1.0)
         assert False
     except ValueError:
         assert True
@@ -531,7 +518,7 @@ def test_rollapply():
     assert actual[3] == 3
     assert actual[4] == 4
 
-    b = pd.DataFrame({'a': a, 'b': a})
+    b = pd.DataFrame({"a": a, "b": a})
 
     actual = b.rollapply(3, np.mean)
 
@@ -543,7 +530,7 @@ def test_rollapply():
 
 
 def test_winsorize():
-    x = pd.Series(range(20), dtype='float')
+    x = pd.Series(range(20), dtype="float")
     res = x.winsorize(limits=0.05)
     assert res.iloc[0] == 1
     assert res.iloc[-1] == 18
@@ -552,58 +539,62 @@ def test_winsorize():
     assert x.iloc[0] == 0
     assert x.iloc[-1] == 19
 
-    x = pd.DataFrame({
-        'a': pd.Series(range(20), dtype='float'),
-        'b': pd.Series(range(20), dtype='float')
-    })
+    x = pd.DataFrame(
+        {
+            "a": pd.Series(range(20), dtype="float"),
+            "b": pd.Series(range(20), dtype="float"),
+        }
+    )
     res = x.winsorize(axis=0, limits=0.05)
 
-    assert res['a'].iloc[0] == 1
-    assert res['b'].iloc[0] == 1
-    assert res['a'].iloc[-1] == 18
-    assert res['b'].iloc[-1] == 18
+    assert res["a"].iloc[0] == 1
+    assert res["b"].iloc[0] == 1
+    assert res["a"].iloc[-1] == 18
+    assert res["b"].iloc[-1] == 18
 
-    assert x['a'].iloc[0] == 0
-    assert x['b'].iloc[0] == 0
-    assert x['a'].iloc[-1] == 19
-    assert x['b'].iloc[-1] == 19
+    assert x["a"].iloc[0] == 0
+    assert x["b"].iloc[0] == 0
+    assert x["a"].iloc[-1] == 19
+    assert x["b"].iloc[-1] == 19
 
 
 def test_rescale():
-    x = pd.Series(range(10), dtype='float')
+    x = pd.Series(range(10), dtype="float")
     res = x.rescale()
 
     assert res.iloc[0] == 0
-    assert res.iloc[4] == (4. - 0.) / (9. - 0.)
+    assert res.iloc[4] == (4.0 - 0.0) / (9.0 - 0.0)
     assert res.iloc[-1] == 1
 
     assert x.iloc[0] == 0
     assert x.iloc[4] == 4
     assert x.iloc[-1] == 9
 
-    x = pd.DataFrame({
-        'a': pd.Series(range(10), dtype='float'),
-        'b': pd.Series(range(10), dtype='float')
-    })
+    x = pd.DataFrame(
+        {
+            "a": pd.Series(range(10), dtype="float"),
+            "b": pd.Series(range(10), dtype="float"),
+        }
+    )
     res = x.rescale(axis=0)
 
-    assert res['a'].iloc[0] == 0
-    assert res['a'].iloc[4] == (4. - 0.) / (9. - 0.)
-    assert res['a'].iloc[-1] == 1
-    assert res['b'].iloc[0] == 0
-    assert res['b'].iloc[4] == (4. - 0.) / (9. - 0.)
-    assert res['b'].iloc[-1] == 1
+    assert res["a"].iloc[0] == 0
+    assert res["a"].iloc[4] == (4.0 - 0.0) / (9.0 - 0.0)
+    assert res["a"].iloc[-1] == 1
+    assert res["b"].iloc[0] == 0
+    assert res["b"].iloc[4] == (4.0 - 0.0) / (9.0 - 0.0)
+    assert res["b"].iloc[-1] == 1
 
-    assert x['a'].iloc[0] == 0
-    assert x['a'].iloc[4] == 4
-    assert x['a'].iloc[-1] == 9
-    assert x['b'].iloc[0] == 0
-    assert x['b'].iloc[4] == 4
-    assert x['b'].iloc[-1] == 9
+    assert x["a"].iloc[0] == 0
+    assert x["a"].iloc[4] == 4
+    assert x["a"].iloc[-1] == 9
+    assert x["b"].iloc[0] == 0
+    assert x["b"].iloc[4] == 4
+    assert x["b"].iloc[-1] == 9
 
 
 def test_annualize():
-    assert ffn.annualize(0.1, 60) == (1.1 ** (1. / (60. / 365)) - 1)
+    assert ffn.annualize(0.1, 60) == (1.1 ** (1.0 / (60.0 / 365)) - 1)
 
 
 def test_calc_sortino_ratio():
@@ -613,7 +604,9 @@ def test_calc_sortino_ratio():
     a = r.calc_sortino_ratio(rf=rf, nperiods=p)
     er = r.to_excess_returns(rf, p)
     negative_returns = np.minimum(er[1:], 0)
-    assert np.allclose(a, np.divide((er.mean() - rf), np.std(negative_returns, ddof=1)) * np.sqrt(p))
+    assert np.allclose(
+        a, np.divide((er.mean() - rf), np.std(negative_returns, ddof=1)) * np.sqrt(p)
+    )
 
 
 def test_calmar_ratio():
@@ -626,22 +619,22 @@ def test_calmar_ratio():
 
 def test_calc_stats():
     # test twelve_month_win_perc divide by zero
-    prices = df.C['2010-10-01':'2011-08-01']
+    prices = df.C["2010-10-01":"2011-08-01"]
     stats = ffn.calc_stats(prices).stats
-    assert pd.isnull(stats['twelve_month_win_perc'])
-    prices = df.C['2009-10-01':'2011-08-01']
+    assert pd.isnull(stats["twelve_month_win_perc"])
+    prices = df.C["2009-10-01":"2011-08-01"]
     stats = ffn.calc_stats(prices).stats
-    assert not pd.isnull(stats['twelve_month_win_perc'])
+    assert not pd.isnull(stats["twelve_month_win_perc"])
 
     # test yearly_sharpe divide by zero
-    prices = df.C['2009-01-01':'2012-01-01']
+    prices = df.C["2009-01-01":"2012-01-01"]
     stats = ffn.calc_stats(prices).stats
-    assert 'yearly_sharpe' in stats.index
+    assert "yearly_sharpe" in stats.index
 
     prices[prices > 0.0] = 1.0
     # throws warnings
     stats = ffn.calc_stats(prices).stats
-    assert pd.isnull(stats['yearly_sharpe'])
+    assert pd.isnull(stats["yearly_sharpe"])
 
 
 def test_calc_sharpe():
@@ -661,7 +654,7 @@ def test_calc_sharpe():
 
 def test_deannualize():
     res = ffn.deannualize(0.05, 252)
-    assert np.allclose(res, np.power(1.05, 1 / 252.) - 1)
+    assert np.allclose(res, np.power(1.05, 1 / 252.0) - 1)
 
 
 def test_to_excess_returns():
@@ -670,8 +663,10 @@ def test_to_excess_returns():
 
     np.allclose(r.to_excess_returns(0), r)
 
-    np.allclose(r.to_excess_returns(rf, nperiods=252),
-                r.to_excess_returns(ffn.deannualize(rf, 252)))
+    np.allclose(
+        r.to_excess_returns(rf, nperiods=252),
+        r.to_excess_returns(ffn.deannualize(rf, 252)),
+    )
 
     np.allclose(r.to_excess_returns(rf), r - rf)
 
@@ -679,141 +674,119 @@ def test_to_excess_returns():
 def test_set_riskfree_rate():
     r = df.to_returns()
 
-    performanceStats = ffn.PerformanceStats(df['MSFT'])
+    performanceStats = ffn.PerformanceStats(df["MSFT"])
     groupStats = ffn.GroupStats(df)
-    daily_returns = df['MSFT'].resample('D').last().dropna().pct_change()
+    daily_returns = df["MSFT"].resample("D").last().dropna().pct_change()
 
     aae(
         performanceStats.daily_sharpe,
         daily_returns.dropna().mean() / (daily_returns.dropna().std()) * (np.sqrt(252)),
-        3
+        3,
     )
 
-    aae(
-        performanceStats.daily_sharpe,
-        groupStats['MSFT'].daily_sharpe,
-        3
-    )
+    aae(performanceStats.daily_sharpe, groupStats["MSFT"].daily_sharpe, 3)
 
-    monthly_returns = df['MSFT'].resample('M').last().pct_change()
+    monthly_returns = df["MSFT"].resample("M").last().pct_change()
     aae(
         performanceStats.monthly_sharpe,
-        monthly_returns.dropna().mean() / (monthly_returns.dropna().std()) * (np.sqrt(12)),
-        3
+        monthly_returns.dropna().mean()
+        / (monthly_returns.dropna().std())
+        * (np.sqrt(12)),
+        3,
     )
-    aae(
-        performanceStats.monthly_sharpe,
-        groupStats['MSFT'].monthly_sharpe,
-        3
-    )
+    aae(performanceStats.monthly_sharpe, groupStats["MSFT"].monthly_sharpe, 3)
 
-    yearly_returns = df['MSFT'].resample('A').last().pct_change()
+    yearly_returns = df["MSFT"].resample("A").last().pct_change()
     aae(
         performanceStats.yearly_sharpe,
         yearly_returns.dropna().mean() / (yearly_returns.dropna().std()) * (np.sqrt(1)),
-        3
+        3,
     )
-    aae(
-        performanceStats.yearly_sharpe,
-        groupStats['MSFT'].yearly_sharpe,
-        3
-    )
+    aae(performanceStats.yearly_sharpe, groupStats["MSFT"].yearly_sharpe, 3)
 
     performanceStats.set_riskfree_rate(0.02)
     groupStats.set_riskfree_rate(0.02)
 
-    daily_returns = df['MSFT'].pct_change()
+    daily_returns = df["MSFT"].pct_change()
     aae(
         performanceStats.daily_sharpe,
-        np.mean(daily_returns.dropna() - 0.02 / 252) / (daily_returns.dropna().std()) * (np.sqrt(252)),
-        3
+        np.mean(daily_returns.dropna() - 0.02 / 252)
+        / (daily_returns.dropna().std())
+        * (np.sqrt(252)),
+        3,
     )
-    aae(
-        performanceStats.daily_sharpe,
-        groupStats['MSFT'].daily_sharpe,
-        3
-    )
+    aae(performanceStats.daily_sharpe, groupStats["MSFT"].daily_sharpe, 3)
 
-    monthly_returns = df['MSFT'].resample('M').last().pct_change()
+    monthly_returns = df["MSFT"].resample("M").last().pct_change()
     aae(
         performanceStats.monthly_sharpe,
-        np.mean(monthly_returns.dropna() - 0.02 / 12) / (monthly_returns.dropna().std()) * (np.sqrt(12)),
-        3
+        np.mean(monthly_returns.dropna() - 0.02 / 12)
+        / (monthly_returns.dropna().std())
+        * (np.sqrt(12)),
+        3,
     )
-    aae(
-        performanceStats.monthly_sharpe,
-        groupStats['MSFT'].monthly_sharpe,
-        3
-    )
+    aae(performanceStats.monthly_sharpe, groupStats["MSFT"].monthly_sharpe, 3)
 
-    yearly_returns = df['MSFT'].resample('A').last().pct_change()
+    yearly_returns = df["MSFT"].resample("A").last().pct_change()
     aae(
         performanceStats.yearly_sharpe,
-        np.mean(yearly_returns.dropna() - 0.02 / 1) / (yearly_returns.dropna().std()) * (np.sqrt(1)),
-        3
+        np.mean(yearly_returns.dropna() - 0.02 / 1)
+        / (yearly_returns.dropna().std())
+        * (np.sqrt(1)),
+        3,
     )
-    aae(
-        performanceStats.yearly_sharpe,
-        groupStats['MSFT'].yearly_sharpe,
-        3
-    )
+    aae(performanceStats.yearly_sharpe, groupStats["MSFT"].yearly_sharpe, 3)
 
     rf = np.zeros(df.shape[0])
     # annual rf is 2%
     rf[1:] = 0.02 / 252
-    rf[0] = 0.
+    rf[0] = 0.0
     # convert to price series
-    rf = 100 * np.cumprod(1 + pd.Series(data=rf, index=df.index, name='rf'))
+    rf = 100 * np.cumprod(1 + pd.Series(data=rf, index=df.index, name="rf"))
 
     performanceStats.set_riskfree_rate(rf)
     groupStats.set_riskfree_rate(rf)
 
-    daily_returns = df['MSFT'].pct_change()
+    daily_returns = df["MSFT"].pct_change()
     rf_daily_returns = rf.pct_change()
     aae(
         performanceStats.daily_sharpe,
-        np.mean(daily_returns - rf_daily_returns) / (daily_returns.dropna().std()) * (np.sqrt(252)),
-        3
+        np.mean(daily_returns - rf_daily_returns)
+        / (daily_returns.dropna().std())
+        * (np.sqrt(252)),
+        3,
     )
-    aae(
-        performanceStats.daily_sharpe,
-        groupStats['MSFT'].daily_sharpe,
-        3
-    )
+    aae(performanceStats.daily_sharpe, groupStats["MSFT"].daily_sharpe, 3)
 
-    monthly_returns = df['MSFT'].resample('M').last().pct_change()
-    rf_monthly_returns = rf.resample('M').last().pct_change()
+    monthly_returns = df["MSFT"].resample("M").last().pct_change()
+    rf_monthly_returns = rf.resample("M").last().pct_change()
     aae(
         performanceStats.monthly_sharpe,
-        np.mean(monthly_returns - rf_monthly_returns) / (monthly_returns.dropna().std()) * (np.sqrt(12)),
-        3
+        np.mean(monthly_returns - rf_monthly_returns)
+        / (monthly_returns.dropna().std())
+        * (np.sqrt(12)),
+        3,
     )
-    aae(
-        performanceStats.monthly_sharpe,
-        groupStats['MSFT'].monthly_sharpe,
-        3
-    )
+    aae(performanceStats.monthly_sharpe, groupStats["MSFT"].monthly_sharpe, 3)
 
-    yearly_returns = df['MSFT'].resample('A').last().pct_change()
-    rf_yearly_returns = rf.resample('A').last().pct_change()
+    yearly_returns = df["MSFT"].resample("A").last().pct_change()
+    rf_yearly_returns = rf.resample("A").last().pct_change()
     aae(
         performanceStats.yearly_sharpe,
-        np.mean(yearly_returns - rf_yearly_returns) / (yearly_returns.dropna().std()) * (np.sqrt(1)),
-        3
+        np.mean(yearly_returns - rf_yearly_returns)
+        / (yearly_returns.dropna().std())
+        * (np.sqrt(1)),
+        3,
     )
-    aae(
-        performanceStats.yearly_sharpe,
-        groupStats['MSFT'].yearly_sharpe,
-        3
-    )
+    aae(performanceStats.yearly_sharpe, groupStats["MSFT"].yearly_sharpe, 3)
 
 
 def test_performance_stats():
-    ps = ffn.PerformanceStats(df['AAPL'])
+    ps = ffn.PerformanceStats(df["AAPL"])
 
     num_stats = len(ps.stats.keys())
     num_unique_stats = len(ps.stats.keys().drop_duplicates())
-    assert(num_stats == num_unique_stats)
+    assert num_stats == num_unique_stats
 
 
 def test_group_stats_calc_stats():
@@ -821,7 +794,7 @@ def test_group_stats_calc_stats():
 
     num_stats = len(gs.stats.index)
     num_unique_stats = len(gs.stats.index.drop_duplicates())
-    assert (num_stats == num_unique_stats)
+    assert num_stats == num_unique_stats
 
 
 def test_resample_returns():
@@ -833,95 +806,78 @@ def test_resample_returns():
 
     sample_mean = np.mean(returns)
 
-    sample_stats = ffn.resample_returns(
-        returns,
-        np.mean,
-        seed=0,
-        num_trials=100
-    )
+    sample_stats = ffn.resample_returns(returns, np.mean, seed=0, num_trials=100)
 
     resampled_mean = np.mean(sample_stats)
     std_resampled_means = np.std(sample_stats, ddof=1)
 
     # resampled statistics should be within 3 std devs of actual
-    assert (np.abs((sample_mean - resampled_mean) / std_resampled_means) < 3)
+    assert np.abs((sample_mean - resampled_mean) / std_resampled_means) < 3
 
     np.random.seed(0)
-    returns = np.random.normal(loc=0.06 / 12, scale=0.20 / np.sqrt(12), size=num_months * 3).reshape(num_months, 3)
+    returns = np.random.normal(
+        loc=0.06 / 12, scale=0.20 / np.sqrt(12), size=num_months * 3
+    ).reshape(num_months, 3)
     returns = pd.DataFrame(returns)
 
     sample_mean = np.mean(returns, axis=0)
 
     sample_stats = ffn.resample_returns(
-        returns,
-        lambda x: np.mean(x, axis=0),
-        seed=0,
-        num_trials=100
+        returns, lambda x: np.mean(x, axis=0), seed=0, num_trials=100
     )
 
     resampled_mean = np.mean(sample_stats)
     std_resampled_means = np.std(sample_stats, ddof=1)
 
     # resampled statistics should be within 3 std devs of actual
-    assert np.all(
-        np.abs(
-            (sample_mean - resampled_mean) / std_resampled_means
-        ) < 3
-    )
+    assert np.all(np.abs((sample_mean - resampled_mean) / std_resampled_means) < 3)
 
     returns = df.to_returns().dropna()
     sample_mean = np.mean(returns, axis=0)
 
     sample_stats = ffn.resample_returns(
-        returns,
-        lambda x: np.mean(x, axis=0),
-        seed=0,
-        num_trials=100
+        returns, lambda x: np.mean(x, axis=0), seed=0, num_trials=100
     )
 
     resampled_mean = np.mean(sample_stats)
     std_resampled_means = np.std(sample_stats, ddof=1)
 
-    assert np.all(
-        np.abs(
-            (sample_mean - resampled_mean) / std_resampled_means
-        ) < 3
-    )
+    assert np.all(np.abs((sample_mean - resampled_mean) / std_resampled_means) < 3)
 
 
 def test_monthly_returns():
 
     dates = [
-        '31/12/2017',
-        '5/1/2018',
-        '9/1/2018',
-        '13/1/2018',
-        '17/1/2018',
-        '21/1/2018',
-        '25/1/2018',
-        '29/1/2018',
-        '2/2/2018',
-        '6/2/2018',
-        '10/2/2018',
-        '14/2/2018',
-        '18/2/2018',
-        '22/2/2018',
-        '26/2/2018',
-        '1/5/2018',
-        '5/5/2018',
-        '9/5/2018',
-        '13/5/2018',
-        '17/5/2018',
-        '21/5/2018',
-        '25/5/2018',
-        '29/5/2018',
-        '2/6/2018',
-        '6/6/2018',
-        '10/6/2018',
-        '14/6/2018',
-        '18/6/2018',
-        '22/6/2018',
-        '26/6/2018'
+        "31/12/2017",
+        "5/1/2018",
+        "9/1/2018",
+        "13/1/2018",
+        "17/1/2018",
+        "21/1/2018",
+        "25/1/2018",
+        "29/1/2018",
+        "2/2/2018",
+        "6/2/2018",
+        "10/2/2018",
+        "14/2/2018",
+        "18/2/2018",
+        "22/2/2018",
+        "26/2/2018",
+        "1/5/2018",
+        "5/5/2018",
+        "9/5/2018",
+        "13/5/2018",
+        "17/5/2018",
+        "21/5/2018",
+        "25/5/2018",
+        "29/5/2018",
+        "2/6/2018",
+        "6/6/2018",
+        "10/6/2018",
+        "14/6/2018",
+        "18/6/2018",
+        "22/6/2018",
+        "26/6/2018",
     ]
 
     prices = [
@@ -954,25 +910,23 @@ def test_monthly_returns():
         139,
         138,
         140,
-        140
+        140,
     ]
 
     df1 = pd.DataFrame(
-        prices,
-        index=pd.to_datetime(dates, format="%d/%m/%Y"),
-        columns=['Price']
+        prices, index=pd.to_datetime(dates, format="%d/%m/%Y"), columns=["Price"]
     )
 
-    obj1 = ffn.PerformanceStats(df1['Price'])
+    obj1 = ffn.PerformanceStats(df1["Price"])
 
-    obj1.monthly_returns == df1['Price'].resample('M').last().pct_change()
+    obj1.monthly_returns == df1["Price"].resample("M").last().pct_change()
 
 
 def test_drawdown_details():
-    drawdown = ffn.to_drawdown_series(df['MSFT'])
+    drawdown = ffn.to_drawdown_series(df["MSFT"])
     drawdown_details = ffn.drawdown_details(drawdown)
 
-    assert (drawdown_details.loc[drawdown_details.index[1], 'Length'] == 18)
+    assert drawdown_details.loc[drawdown_details.index[1], "Length"] == 18
 
     num_years = 30
     num_months = num_years * 12

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -16,12 +16,12 @@ ts = df['AAPL'][0:10]
 
 def test_mtd_ytd():
     data = df['AAPL']
-    
+
     # Intramonth
     prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2004-12-25')]
-    dp = prices.resample("D").last().dropna()
-    mp = prices.resample("M").last().dropna()
-    yp = prices.resample("A").last().dropna()
+    dp = prices.resample('D').last().dropna()
+    mp = prices.resample('M').last().dropna()
+    yp = prices.resample('A').last().dropna()
     mtd_actual = ffn.calc_mtd(dp, mp)
     ytd_actual = ffn.calc_ytd(dp, yp)
 
@@ -30,9 +30,9 @@ def test_mtd_ytd():
 
     # Year change - first month
     prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2005-01-15')]
-    dp = prices.resample("D").last().dropna()
-    mp = prices.resample("M").last().dropna()
-    yp = prices.resample("A").last().dropna()
+    dp = prices.resample('D').last().dropna()
+    mp = prices.resample('M').last().dropna()
+    yp = prices.resample('A').last().dropna()
     mtd_actual = ffn.calc_mtd(dp, mp)
     ytd_actual = ffn.calc_ytd(dp, yp)
 
@@ -41,9 +41,9 @@ def test_mtd_ytd():
 
     # Year change - second month
     prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2005-02-15')]
-    dp = prices.resample("D").last().dropna()
-    mp = prices.resample("M").last().dropna()
-    yp = prices.resample("A").last().dropna()
+    dp = prices.resample('D').last().dropna()
+    mp = prices.resample('M').last().dropna()
+    yp = prices.resample('A').last().dropna()
     mtd_actual = ffn.calc_mtd(dp, mp)
     ytd_actual = ffn.calc_ytd(dp, yp)
 
@@ -52,9 +52,9 @@ def test_mtd_ytd():
 
     # Single day
     prices = data[[pd.to_datetime('2004-12-10')]]
-    dp = prices.resample("D").last().dropna()
-    mp = prices.resample("M").last().dropna()
-    yp = prices.resample("A").last().dropna()
+    dp = prices.resample('D').last().dropna()
+    mp = prices.resample('M').last().dropna()
+    yp = prices.resample('A').last().dropna()
     mtd_actual = ffn.calc_mtd(dp, mp)
     ytd_actual = ffn.calc_ytd(dp, yp)
 
@@ -341,8 +341,6 @@ def test_calc_erc_weights():
     aae(actual['AAPL'], 0.234, 3)
     aae(actual['MSFT'], 0.409, 3)
     aae(actual['C'], 0.356, 3)
-
-
 
 
 def test_calc_total_return():
@@ -890,6 +888,7 @@ def test_resample_returns():
         ) < 3
     )
 
+
 def test_monthly_returns():
 
     dates = [
@@ -960,14 +959,13 @@ def test_monthly_returns():
 
     df1 = pd.DataFrame(
         prices,
-        index = pd.to_datetime(dates,format = "%d/%m/%Y"),
+        index=pd.to_datetime(dates, format="%d/%m/%Y"),
         columns=['Price']
     )
 
     obj1 = ffn.PerformanceStats(df1['Price'])
 
     obj1.monthly_returns == df1['Price'].resample('M').last().pct_change()
-
 
 
 def test_drawdown_details():
@@ -984,5 +982,3 @@ def test_drawdown_details():
 
     drawdown = ffn.to_drawdown_series(returns)
     drawdown_details = ffn.drawdown_details(drawdown, index_type=drawdown.index)
-
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,53 @@ except FileNotFoundError as e:
 ts = df['AAPL'][0:10]
 
 
+def test_mtd_ytd():
+    data = df['AAPL']
+    
+    # Intramonth
+    prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2004-12-25')]
+    dp = prices.resample("D").last().dropna()
+    mp = prices.resample("M").last().dropna()
+    yp = prices.resample("A").last().dropna()
+    mtd_actual = ffn.calc_mtd(dp, mp)
+    ytd_actual = ffn.calc_ytd(dp, yp)
+
+    aae(mtd_actual, -0.0175, 4)
+    assert mtd_actual == ytd_actual
+
+    # Year change - first month
+    prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2005-01-15')]
+    dp = prices.resample("D").last().dropna()
+    mp = prices.resample("M").last().dropna()
+    yp = prices.resample("A").last().dropna()
+    mtd_actual = ffn.calc_mtd(dp, mp)
+    ytd_actual = ffn.calc_ytd(dp, yp)
+
+    aae(mtd_actual, 0.0901, 4)
+    assert mtd_actual == ytd_actual
+
+    # Year change - second month
+    prices = data[pd.to_datetime('2004-12-10'):pd.to_datetime('2005-02-15')]
+    dp = prices.resample("D").last().dropna()
+    mp = prices.resample("M").last().dropna()
+    yp = prices.resample("A").last().dropna()
+    mtd_actual = ffn.calc_mtd(dp, mp)
+    ytd_actual = ffn.calc_ytd(dp, yp)
+
+    aae(mtd_actual, 0.1497, 4)
+    aae(ytd_actual, 0.3728, 4)
+
+    # Single day
+    prices = data[[pd.to_datetime('2004-12-10')]]
+    dp = prices.resample("D").last().dropna()
+    mp = prices.resample("M").last().dropna()
+    yp = prices.resample("A").last().dropna()
+    mtd_actual = ffn.calc_mtd(dp, mp)
+    ytd_actual = ffn.calc_ytd(dp, yp)
+
+    assert mtd_actual == ytd_actual == 0
+
+
 def test_to_returns_ts():
     data = ts
     actual = data.to_returns()


### PR DESCRIPTION
**Fixed bug in YTD and MTD calculation.** 
YTD and MTD are not calculated for short return series, and are not necessarily equal to total_return. 

MTD is only assigned something other than total_return, if more than one monthly return exists - which is unnecessary. 

Same issue for YTD - but with a stricter condition of more data before it is calculated. 

MTD and YTD returns are calculated after validating that a single daily return is available. If in the same month, the dp series can be used to find MTD, else the second to last value in the mp series is used. Same method for YTD calculation.