### PR TITLE
Replace `applymap` with `map`

### DIFF
--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -179,7 +179,4 @@ def as_format(item, format_str=".2f"):
     """
     Map a format string over a pandas object.
     """
-    if isinstance(item, pd.Series):
-        return item.map(lambda x: format(x, format_str))
-    elif isinstance(item, pd.DataFrame):
-        return item.applymap(lambda x: format(x, format_str))
+    return item.map(lambda x: format(x, format_str))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -452,7 +452,7 @@ def test_random_weights():
     for i in df.index:
         df.loc[i] = ffn.random_weights(n, bounds, tot)
     assert df.sum(axis=1).apply(lambda x: np.round(x, 4) == tot).all()
-    assert df.applymap(lambda x: (x >= low and x <= high)).all().all()
+    assert df.map(lambda x: (x >= low and x <= high)).all().all()
 
     n = 4
     bounds = (0.0, 0.25)
@@ -465,7 +465,7 @@ def test_random_weights():
         df.loc[i] = ffn.random_weights(n, bounds, tot)
     assert df.sum(axis=1).apply(lambda x: np.round(x, 4) == tot).all()
     assert (
-        df.applymap(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
+        df.map(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
         .all()
         .all()
     )
@@ -481,7 +481,7 @@ def test_random_weights():
         df.loc[i] = ffn.random_weights(n, bounds, tot)
     assert df.sum(axis=1).apply(lambda x: np.round(x, 4) == tot).all()
     assert (
-        df.applymap(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
+        df.map(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
         .all()
         .all()
     )
@@ -497,7 +497,7 @@ def test_random_weights():
         df.loc[i] = ffn.random_weights(n, bounds, tot)
     assert df.sum(axis=1).apply(lambda x: np.round(x, 4) == tot).all()
     assert (
-        df.applymap(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
+        df.map(lambda x: (np.round(x, 2) >= low and np.round(x, 2) <= high))
         .all()
         .all()
     )


### PR DESCRIPTION
Previously, `map` was used for `Series` class while `applymap` was used for the `DataFrame` class. Now Pandas has deprecated `applymap` and suggest using `map` for `DataFrame` as well.

![image](https://github.com/pmorissette/ffn/assets/62388269/a5c639ad-0751-4c52-bfa6-ef54d95fb93f)
