### PR TITLE
Add typing for the `utils` file

### DIFF
--- a/ffn/data.py
+++ b/ffn/data.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Sequence, Union
 import ffn
 import pandas as pd
 import yfinance
@@ -121,7 +121,7 @@ def _download_web(name: str, **kwargs) -> pd.DataFrame:
 
 
 @utils.memoize
-def yf(ticker: str, field, start=None, end=None, mrefresh=False) -> pd.Series | pd.DataFrame:
+def yf(ticker: str, field, start=None, end=None, mrefresh=False) -> Union[pd.Series, pd.DataFrame]:
     if field is None:
         field = "Adj Close"
 

--- a/ffn/data.py
+++ b/ffn/data.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 import ffn
 import pandas as pd
 import yfinance
@@ -14,7 +15,7 @@ if Version(pd.__version__) > Version("0.23.0"):
 
 
 @utils.memoize
-def get(tickers, provider=None, common_dates=True, forward_fill=False, clean_tickers=True, column_names=None, ticker_field_sep=":", mrefresh=False, existing=None, **kwargs):
+def get(tickers: Sequence[str], provider=None, common_dates=True, forward_fill=False, clean_tickers=True, column_names=None, ticker_field_sep=":", mrefresh=False, existing=None, **kwargs) -> pd.DataFrame:
     """
     Helper function for retrieving data as a DataFrame.
 
@@ -92,7 +93,7 @@ def get(tickers, provider=None, common_dates=True, forward_fill=False, clean_tic
 
 
 @utils.memoize
-def web(ticker, field=None, start=None, end=None, mrefresh=False, source="yahoo"):
+def web(ticker: str, field=None, start=None, end=None, mrefresh=False, source="yahoo"):
     """
     Data provider wrapper around pandas.io.data provider. Provides
     memoization.
@@ -112,7 +113,7 @@ def web(ticker, field=None, start=None, end=None, mrefresh=False, source="yahoo"
 
 
 @utils.memoize
-def _download_web(name, **kwargs):
+def _download_web(name: str, **kwargs) -> pd.DataFrame:
     """
     Thin wrapper to enable memoization
     """
@@ -120,7 +121,7 @@ def _download_web(name, **kwargs):
 
 
 @utils.memoize
-def yf(ticker, field, start=None, end=None, mrefresh=False):
+def yf(ticker: str, field, start=None, end=None, mrefresh=False) -> pd.Series | pd.DataFrame:
     if field is None:
         field = "Adj Close"
 
@@ -138,7 +139,7 @@ def yf(ticker, field, start=None, end=None, mrefresh=False):
 
 
 @utils.memoize
-def csv(ticker, path="data.csv", field="", mrefresh=False, **kwargs):
+def csv(ticker: str, path="data.csv", field="", mrefresh=False, **kwargs) -> pd.Series:
     """
     Data provider wrapper around pandas' read_csv. Provides memoization.
     """

--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -118,7 +118,7 @@ def fmtn(number: float) -> str:
     return format(number, ".2f")
 
 
-def get_freq_name(period: str) -> str | None:
+def get_freq_name(period: str) -> Union[str, None]:
     period = period.upper()
     periods = {
         "B": "business day",

--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -3,7 +3,7 @@ import re
 import decorator
 import numpy as np
 import pandas as pd
-from typing import Any, Sequence
+from typing import List, Sequence, Tuple, Union
 
 try:
     import cPickle as pickle
@@ -46,7 +46,7 @@ def memoize(f, refresh_keyword="mrefresh"):
     return decorator.decorator(_memoize, f)
 
 
-def parse_arg(arg: Any):
+def parse_arg(arg: Union[str, List[str], Tuple[str]]):
     """
     Parses arguments for convenience. Argument can be a
     csv list ('a,b,c'), a string, a list, a tuple.
@@ -176,7 +176,7 @@ def as_percent(self, digits=2):
     return as_format(self, ".%s%%" % digits)
 
 
-def as_format(item: pd.DataFrame | pd.Series, format_str=".2f") -> pd.DataFrame | pd.Series:
+def as_format(item: Union[pd.DataFrame, pd.Series], format_str=".2f") -> Union[pd.DataFrame, pd.Series]:
     """
     Map a format string over a pandas object.
     """

--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -3,6 +3,7 @@ import re
 import decorator
 import numpy as np
 import pandas as pd
+from typing import Any, Sequence
 
 try:
     import cPickle as pickle
@@ -45,7 +46,7 @@ def memoize(f, refresh_keyword="mrefresh"):
     return decorator.decorator(_memoize, f)
 
 
-def parse_arg(arg):
+def parse_arg(arg: Any):
     """
     Parses arguments for convenience. Argument can be a
     csv list ('a,b,c'), a string, a list, a tuple.
@@ -66,7 +67,7 @@ def parse_arg(arg):
     return arg
 
 
-def clean_ticker(ticker):
+def clean_ticker(ticker: str) -> str:
     """
     Cleans a ticker for easier use throughout MoneyTree
 
@@ -83,14 +84,14 @@ def clean_ticker(ticker):
     return res.lower()
 
 
-def clean_tickers(tickers):
+def clean_tickers(tickers: Sequence[str]) -> list[str]:
     """
     Maps clean_ticker over tickers.
     """
     return [clean_ticker(x) for x in tickers]
 
 
-def fmtp(number):
+def fmtp(number: float) -> str:
     """
     Formatting helper - percent
     """
@@ -99,7 +100,7 @@ def fmtp(number):
     return format(number, ".2%")
 
 
-def fmtpn(number):
+def fmtpn(number: float) -> str:
     """
     Formatting helper - percent no % sign
     """
@@ -108,7 +109,7 @@ def fmtpn(number):
     return format(number * 100, ".2f")
 
 
-def fmtn(number):
+def fmtn(number: float) -> str:
     """
     Formatting helper - float
     """
@@ -117,7 +118,7 @@ def fmtn(number):
     return format(number, ".2f")
 
 
-def get_freq_name(period):
+def get_freq_name(period: str) -> str | None:
     period = period.upper()
     periods = {
         "B": "business day",
@@ -152,7 +153,7 @@ def get_freq_name(period):
         return None
 
 
-def scale(val, src, dst):
+def scale(val: float, src: Sequence[float], dst: Sequence[float]) -> float:
     """
     Scale value from src range to dst range.
     If value outside bounds, it is clipped and set to
@@ -175,7 +176,7 @@ def as_percent(self, digits=2):
     return as_format(self, ".%s%%" % digits)
 
 
-def as_format(item, format_str=".2f"):
+def as_format(item: pd.DataFrame | pd.Series, format_str=".2f") -> pd.DataFrame | pd.Series:
     """
     Map a format string over a pandas object.
     """


### PR DESCRIPTION
I personally use type checking with python with the help of type hinting for autocompletions. It is very common for high used modules to integrate type hinting for good integration and workflow with other modules and files.

Its absence is fairly noticeable by me. Example from my code is shown below. Assuming that the `utils.get` method returns a dataframe rather than an unknown object, might greatly increase the user's experience via autocompletion.
![image](https://github.com/pmorissette/ffn/assets/62388269/e0592f1a-8795-4127-b954-62912c66a48d)