### PR TITLE
test: fix FutureWarning in test_resample_returns

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -857,8 +857,8 @@ def test_resample_returns(df):
         returns, lambda x: np.mean(x, axis=0), seed=0, num_trials=100
     )
 
-    resampled_mean = np.mean(sample_stats)
-    std_resampled_means = np.std(sample_stats, ddof=1)
+    resampled_mean = np.mean(sample_stats, axis=0)
+    std_resampled_means = np.std(sample_stats, ddof=1, axis=0)
 
     # resampled statistics should be within 3 std devs of actual
     assert np.all(np.abs((sample_mean - resampled_mean) / std_resampled_means) < 3)
@@ -870,8 +870,8 @@ def test_resample_returns(df):
         returns, lambda x: np.mean(x, axis=0), seed=0, num_trials=100
     )
 
-    resampled_mean = np.mean(sample_stats)
-    std_resampled_means = np.std(sample_stats, ddof=1)
+    resampled_mean = np.mean(sample_stats, axis=0)
+    std_resampled_means = np.std(sample_stats, ddof=1, axis=0)
 
     assert np.all(np.abs((sample_mean - resampled_mean) / std_resampled_means) < 3)
 


### PR DESCRIPTION
## Summary

`np.mean(sample_stats)` and `np.std(sample_stats, ddof=1)` in `test_resample_returns` delegate to `DataFrame.mean(axis=None)` / `DataFrame.std(axis=None)`, which is deprecated in pandas and will change behavior in a future version. This produces 2 FutureWarnings per test run.

Adding explicit `axis=0` preserves current behavior and silences the warnings.

## Changes

- Add `axis=0` to 4 calls in `test_resample_returns` (2x `np.mean`, 2x `np.std`)

## Test plan

- `python -W error::FutureWarning -m pytest tests/test_core.py::test_resample_returns` — passes (previously failed)
- Full test suite passes (44/44)