### PR TITLE
Add FXMacroData data provider

### DIFF
--- a/ffn/data.py
+++ b/ffn/data.py
@@ -250,15 +250,15 @@ def fxmacrodata(
         params["indicators"] = indicator
 
     api_key = api_key or os.getenv("FXMACRODATA_API_KEY") or os.getenv("FXMD_API_KEY")
-    if api_key:
-        params["api_key"] = api_key
-
     query = urlencode(params)
     url = f"{base_url.rstrip('/')}/forex/{base_currency.lower()}/{quote_currency.lower()}"
     if query:
         url = f"{url}?{query}"
 
-    request = Request(url, headers={"Accept": "application/json"})
+    headers = {"Accept": "application/json"}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    request = Request(url, headers=headers)
     try:
         with urlopen(request, timeout=timeout) as response:
             payload = json.load(response)

--- a/ffn/data.py
+++ b/ffn/data.py
@@ -1,5 +1,10 @@
+import json
+import os
 import warnings
 from typing import Sequence, Union
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 import pandas as pd
 import yfinance
@@ -155,6 +160,140 @@ def csv(ticker: str, path="data.csv", field="", mrefresh=False, **kwargs) -> pd.
         raise ValueError("Ticker(field) not present in csv file!")
 
     return df[tf]
+
+
+FXMACRODATA_API_BASE_URL = "https://fxmacrodata.com/api/v1"
+
+_FXMACRODATA_INDICATOR_FIELDS = {
+    "sma_20": "sma_20",
+    "sma_50": "sma_50",
+    "sma_200": "sma_200",
+    "ema_12": "ema_12",
+    "ema_20": "ema_20",
+    "ema_26": "ema_26",
+    "ema_50": "ema_50",
+    "ema_200": "ema_200",
+    "rsi_14": "rsi_14",
+    "atr_14": "atr_14",
+    "adx_14": "adx_14",
+    "macd": "macd",
+    "macd_signal": "macd",
+    "macd_histogram": "macd",
+    "bb_upper": "bollinger_bands",
+    "bb_middle": "bollinger_bands",
+    "bb_lower": "bollinger_bands",
+}
+
+
+def _format_fxmacrodata_date(value):
+    if value is None:
+        return None
+    return pd.Timestamp(value).date().isoformat()
+
+
+def _split_fxmacrodata_pair(ticker: str) -> tuple[str, str]:
+    normalized = "".join(char for char in ticker.upper() if char.isalpha())
+    if len(normalized) != 6:
+        raise ValueError("FXMacroData tickers must look like 'EURUSD' or 'EUR/USD'")
+    return normalized[:3], normalized[3:]
+
+
+def _read_fxmacrodata_error(error: HTTPError) -> str:
+    try:
+        body = error.read().decode("utf-8").strip()
+    except Exception:
+        body = ""
+    message = f"FXMacroData API error {error.code}"
+    if body:
+        message = f"{message}: {body}"
+    return message
+
+
+@utils.memoize
+def fxmacrodata(
+    ticker: str,
+    field=None,
+    start=None,
+    end=None,
+    api_key=None,
+    base_url: str = FXMACRODATA_API_BASE_URL,
+    timeout: float = 30,
+    mrefresh=False,
+) -> pd.Series:
+    """
+    Data provider for FXMacroData daily FX spot rates.
+
+    Use with :func:`ffn.get` by passing this function as the provider:
+
+    >>> prices = ffn.get("EURUSD", provider=ffn.data.fxmacrodata, start="2024-01-01", api_key="...")
+
+    ``ticker`` accepts six-character FX pairs such as ``EURUSD`` or separated
+    forms such as ``EUR/USD``. By default the returned series contains the
+    ``val`` field from the FXMacroData response. Technical fields such as
+    ``sma_20`` or ``rsi_14`` can be requested via ffn's ticker field syntax,
+    for example ``EURUSD:sma_20``. Pass ``api_key`` or set
+    ``FXMACRODATA_API_KEY`` or ``FXMD_API_KEY`` for protected pairs.
+    """
+    base_currency, quote_currency = _split_fxmacrodata_pair(ticker)
+    output_field = field or "val"
+
+    params = {}
+    start_date = _format_fxmacrodata_date(start)
+    end_date = _format_fxmacrodata_date(end)
+    if start_date:
+        params["start_date"] = start_date
+    if end_date:
+        params["end_date"] = end_date
+
+    indicator = _FXMACRODATA_INDICATOR_FIELDS.get(output_field)
+    if indicator:
+        params["indicators"] = indicator
+
+    api_key = api_key or os.getenv("FXMACRODATA_API_KEY") or os.getenv("FXMD_API_KEY")
+    if api_key:
+        params["api_key"] = api_key
+
+    query = urlencode(params)
+    url = f"{base_url.rstrip('/')}/forex/{base_currency.lower()}/{quote_currency.lower()}"
+    if query:
+        url = f"{url}?{query}"
+
+    request = Request(url, headers={"Accept": "application/json"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            payload = json.load(response)
+    except HTTPError as error:
+        if error.code == 401:
+            raise PermissionError(_read_fxmacrodata_error(error)) from error
+        raise ValueError(_read_fxmacrodata_error(error)) from error
+
+    rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        raise ValueError("FXMacroData response did not include a data list")
+
+    records = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        date_value = row.get("date")
+        series_value = row.get(output_field)
+        if date_value is None or series_value is None:
+            continue
+        records.append((pd.Timestamp(date_value), series_value))
+
+    if not records:
+        raise ValueError(f"FXMacroData response did not include dated '{output_field}' rows for {base_currency}/{quote_currency}")
+
+    series = pd.Series(
+        data=[value for _, value in records],
+        index=pd.DatetimeIndex([date for date, _ in records]),
+        name=ticker,
+    )
+    series = pd.to_numeric(series, errors="coerce").dropna()
+    if series.empty:
+        raise ValueError(f"FXMacroData response did not include numeric '{output_field}' rows for {base_currency}/{quote_currency}")
+
+    return series[~series.index.duplicated(keep="last")].sort_index()
 
 
 DEFAULT_PROVIDER = yf

--- a/ffn/data.py
+++ b/ffn/data.py
@@ -209,8 +209,7 @@ def _read_fxmacrodata_error(error: HTTPError) -> str:
     return message
 
 
-@utils.memoize
-def fxmacrodata(
+def _fxmacrodata_fetch(
     ticker: str,
     field=None,
     start=None,
@@ -218,22 +217,7 @@ def fxmacrodata(
     api_key=None,
     base_url: str = FXMACRODATA_API_BASE_URL,
     timeout: float = 30,
-    mrefresh=False,
 ) -> pd.Series:
-    """
-    Data provider for FXMacroData daily FX spot rates.
-
-    Use with :func:`ffn.get` by passing this function as the provider:
-
-    >>> prices = ffn.get("EURUSD", provider=ffn.data.fxmacrodata, start="2024-01-01", api_key="...")
-
-    ``ticker`` accepts six-character FX pairs such as ``EURUSD`` or separated
-    forms such as ``EUR/USD``. By default the returned series contains the
-    ``val`` field from the FXMacroData response. Technical fields such as
-    ``sma_20`` or ``rsi_14`` can be requested via ffn's ticker field syntax,
-    for example ``EURUSD:sma_20``. Pass ``api_key`` or set
-    ``FXMACRODATA_API_KEY`` or ``FXMD_API_KEY`` for protected pairs.
-    """
     base_currency, quote_currency = _split_fxmacrodata_pair(ticker)
     output_field = field or "val"
 
@@ -294,6 +278,57 @@ def fxmacrodata(
         raise ValueError(f"FXMacroData response did not include numeric '{output_field}' rows for {base_currency}/{quote_currency}")
 
     return series[~series.index.duplicated(keep="last")].sort_index()
+
+
+@utils.memoize
+def _fxmacrodata_cached(
+    ticker: str,
+    field=None,
+    start=None,
+    end=None,
+    base_url: str = FXMACRODATA_API_BASE_URL,
+    timeout: float = 30,
+    mrefresh=False,
+) -> pd.Series:
+    """Cache public FXMacroData responses without including credentials in the cache key."""
+    return _fxmacrodata_fetch(ticker, field=field, start=start, end=end, base_url=base_url, timeout=timeout)
+
+
+def fxmacrodata(
+    ticker: str,
+    field=None,
+    start=None,
+    end=None,
+    api_key=None,
+    base_url: str = FXMACRODATA_API_BASE_URL,
+    timeout: float = 30,
+    mrefresh=False,
+) -> pd.Series:
+    """
+    Data provider for FXMacroData daily FX spot rates.
+
+    Use with :func:`ffn.get` by passing this function as the provider:
+
+    >>> prices = ffn.get("EURUSD", provider=ffn.data.fxmacrodata, start="2024-01-01", api_key="...")
+
+    ``ticker`` accepts six-character FX pairs such as ``EURUSD`` or separated
+    forms such as ``EUR/USD``. By default the returned series contains the
+    ``val`` field from the FXMacroData response. Technical fields such as
+    ``sma_20`` or ``rsi_14`` can be requested via ffn's ticker field syntax,
+    for example ``EURUSD:sma_20``. Pass ``api_key`` or set
+    ``FXMACRODATA_API_KEY`` or ``FXMD_API_KEY`` for protected pairs.
+
+    Public responses are memoized. Authenticated requests are intentionally not
+    cached so an API key is never serialized into ffn's in-memory cache key.
+    """
+    api_key = api_key or os.getenv("FXMACRODATA_API_KEY") or os.getenv("FXMD_API_KEY")
+    if api_key:
+        return _fxmacrodata_fetch(
+            ticker, field=field, start=start, end=end, api_key=api_key, base_url=base_url, timeout=timeout
+        )
+    return _fxmacrodata_cached(
+        ticker, field=field, start=start, end=end, base_url=base_url, timeout=timeout, mrefresh=mrefresh
+    )
 
 
 DEFAULT_PROVIDER = yf

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,98 @@
+import io
+import json
+from unittest import mock
+
+import ffn
+import pandas as pd
+import pytest
+
+
+class FakeResponse(io.StringIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+
+def test_fxmacrodata_fetches_spot_series():
+    payload = {
+        "data": [
+            {"date": "2024-01-03", "val": 1.0920},
+            {"date": "2024-01-01", "val": "1.1038"},
+            {"date": "2024-01-02", "val": 1.0943},
+        ]
+    }
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["accept"] = request.get_header("Accept")
+        captured["timeout"] = timeout
+        return FakeResponse(json.dumps(payload))
+
+    with mock.patch.object(ffn.data, "urlopen", side_effect=fake_urlopen):
+        actual = ffn.data.fxmacrodata(
+            "eur/usd",
+            start="2024-01-01",
+            end=pd.Timestamp("2024-01-31"),
+            api_key="test-key",
+            timeout=12,
+            mrefresh=True,
+        )
+
+    expected = pd.Series(
+        [1.1038, 1.0943, 1.0920],
+        index=pd.to_datetime(["2024-01-01", "2024-01-02", "2024-01-03"]),
+        name="eur/usd",
+    )
+    pd.testing.assert_series_equal(actual, expected)
+    assert captured == {
+        "url": "https://fxmacrodata.com/api/v1/forex/eur/usd?start_date=2024-01-01&end_date=2024-01-31&api_key=test-key",
+        "accept": "application/json",
+        "timeout": 12,
+    }
+
+
+def test_fxmacrodata_requests_indicator_for_technical_field():
+    payload = {"data": [{"date": "2024-01-03", "rsi_14": 54.25}]}
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        return FakeResponse(json.dumps(payload))
+
+    with mock.patch.object(ffn.data, "urlopen", side_effect=fake_urlopen):
+        actual = ffn.data.fxmacrodata("EURUSD", field="rsi_14", start="2024-01-01", mrefresh=True)
+
+    assert captured["url"] == "https://fxmacrodata.com/api/v1/forex/eur/usd?start_date=2024-01-01&indicators=rsi_14"
+    assert actual.loc[pd.Timestamp("2024-01-03")] == 54.25
+
+
+def test_fxmacrodata_integrates_with_get():
+    payload = {"data": [{"date": "2024-01-01", "val": 1.1038}]}
+
+    def fake_urlopen(request, timeout):
+        return FakeResponse(json.dumps(payload))
+
+    with mock.patch.object(ffn.data, "urlopen", side_effect=fake_urlopen):
+        actual = ffn.get("EURUSD", provider=ffn.data.fxmacrodata, start="2024-01-01", mrefresh=True)
+
+    expected = pd.DataFrame({"eurusd": [1.1038]}, index=pd.to_datetime(["2024-01-01"]))
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_fxmacrodata_rejects_unknown_pair_shape():
+    with pytest.raises(ValueError, match="EURUSD"):
+        ffn.data.fxmacrodata("EUR", mrefresh=True)
+
+
+def test_fxmacrodata_rejects_missing_rows():
+    payload = {"data": [{"date": "2024-01-01"}]}
+
+    def fake_urlopen(request, timeout):
+        return FakeResponse(json.dumps(payload))
+
+    with mock.patch.object(ffn.data, "urlopen", side_effect=fake_urlopen):
+        with pytest.raises(ValueError, match="dated 'val' rows"):
+            ffn.data.fxmacrodata("EURUSD", mrefresh=True)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -28,6 +28,7 @@ def test_fxmacrodata_fetches_spot_series():
     def fake_urlopen(request, timeout):
         captured["url"] = request.full_url
         captured["accept"] = request.get_header("Accept")
+        captured["api_key"] = request.get_header("X-api-key")
         captured["timeout"] = timeout
         return FakeResponse(json.dumps(payload))
 
@@ -48,8 +49,9 @@ def test_fxmacrodata_fetches_spot_series():
     )
     pd.testing.assert_series_equal(actual, expected)
     assert captured == {
-        "url": "https://fxmacrodata.com/api/v1/forex/eur/usd?start_date=2024-01-01&end_date=2024-01-31&api_key=test-key",
+        "url": "https://fxmacrodata.com/api/v1/forex/eur/usd?start_date=2024-01-01&end_date=2024-01-31",
         "accept": "application/json",
+        "api_key": "test-key",
         "timeout": 12,
     }
 
@@ -67,6 +69,23 @@ def test_fxmacrodata_requests_indicator_for_technical_field():
 
     assert captured["url"] == "https://fxmacrodata.com/api/v1/forex/eur/usd?start_date=2024-01-01&indicators=rsi_14"
     assert actual.loc[pd.Timestamp("2024-01-03")] == 54.25
+
+
+def test_fxmacrodata_omits_api_key_header_when_not_configured(monkeypatch):
+    monkeypatch.delenv("FXMACRODATA_API_KEY", raising=False)
+    monkeypatch.delenv("FXMD_API_KEY", raising=False)
+    captured = {}
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["api_key"] = request.get_header("X-api-key")
+        return FakeResponse(json.dumps({"data": [{"date": "2024-01-03", "val": 1.092}]}))
+
+    with mock.patch.object(ffn.data, "urlopen", side_effect=fake_urlopen):
+        ffn.data.fxmacrodata("EURUSD", mrefresh=True)
+
+    assert "api_key" not in captured["url"]
+    assert captured["api_key"] is None
 
 
 def test_fxmacrodata_integrates_with_get():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -88,6 +88,26 @@ def test_fxmacrodata_omits_api_key_header_when_not_configured(monkeypatch):
     assert captured["api_key"] is None
 
 
+def test_fxmacrodata_does_not_serialize_api_keys_into_cache_keys():
+    cache = ffn.data._fxmacrodata_cached.mcache
+    cache.clear()
+    request_keys = []
+
+    def fake_urlopen(request, timeout):
+        request_keys.append(request.get_header("X-api-key"))
+        return FakeResponse(json.dumps({"data": [{"date": "2024-01-03", "val": 1.092}]}))
+
+    try:
+        with mock.patch.object(ffn.data, "urlopen", side_effect=fake_urlopen):
+            ffn.data.fxmacrodata("EURUSD", api_key="first-secret")
+            ffn.data.fxmacrodata("EURUSD", api_key="second-secret")
+
+        assert request_keys == ["first-secret", "second-secret"]
+        assert not cache
+    finally:
+        cache.clear()
+
+
 def test_fxmacrodata_integrates_with_get():
     payload = {"data": [{"date": "2024-01-01", "val": 1.1038}]}
 


### PR DESCRIPTION
## Summary

- add `ffn.data.fxmacrodata`, a provider for FXMacroData daily FX spot series
- support `EURUSD` / `EUR/USD` pair parsing, `start` / `end`, API-key query auth, and `FXMACRODATA_API_KEY` / `FXMD_API_KEY` env fallbacks
- support technical fields such as `EURUSD:rsi_14` through the existing `ffn.get` ticker-field syntax
- add mocked tests for request construction, response parsing, technical fields, invalid tickers, and `ffn.get` integration

## Why

`bt` re-exports `ffn.get` and `ffn.data`, so this adds reusable data-provider functionality at the shared data-access layer instead of adding a vendor-specific `bt` example script.

## Validation

- `python -m ruff check ffn\data.py tests\test_data.py`
- `.\env\Scripts\python.exe -m pytest`