### PR TITLE
Fix per-series stats distortion from NaNs in other columns

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -783,6 +783,11 @@ class GroupStats(dict):
     Individual PerformanceStats objects can be accessed via index
     position or name via the [] accessor.
 
+    Each series' stats are computed from that series' own available
+    observations, matching what PerformanceStats returns for the series
+    on its own. Cross-sectional views (prices, correlations) use the
+    merged calendar, keeping only dates where every series has data.
+
     Args:
         * prices (Series): Multiple price series to be compared.
 
@@ -808,11 +813,14 @@ class GroupStats(dict):
                 names.append(getattr(p, "name", "n/a"))
         self._names = names
 
-        # store original prices
-        self._prices = merge(*prices).dropna()
+        # store original prices with each series' own calendar, and the
+        # merged intersection used for cross-sectional views
+        self._prices_full = merge(*prices)
+        self._prices = self._prices_full.dropna()
 
         # proper ordering
         self._prices = self._prices[self._names]
+        self._prices_full = self._prices_full[self._names]
 
         # check for duplicate columns
         if len(self._prices.columns) != len(set(self._prices.columns)):
@@ -824,7 +832,7 @@ class GroupStats(dict):
         self._start = self._prices.index[0]
         self._end = self._prices.index[-1]
         # calculate stats for entire series
-        self._update(self._prices)
+        self._update(self._prices, self._prices_full)
 
     def __getitem__(self, key):
         if isinstance(key, int):
@@ -833,14 +841,18 @@ class GroupStats(dict):
         else:
             return self.get(key)
 
-    def _update(self, data):
-        self._calculate(data)
+    def _update(self, data, full_data=None):
+        self._calculate(data, full_data)
         self._update_stats()
 
-    def _calculate(self, data):
+    def _calculate(self, data, full_data=None):
         self.prices = data
+        # build each series' stats from its own observations so that rows
+        # missing in one series are not silently dropped from the others
+        if full_data is None:
+            full_data = data
         for c in data.columns:
-            prc = data[c]
+            prc = full_data[c].dropna()
             self[c] = PerformanceStats(prc)
 
     def _stats(self):
@@ -944,7 +956,7 @@ class GroupStats(dict):
         """
         start = self._start if start is None else pd.to_datetime(start)
         end = self._end if end is None else pd.to_datetime(end)
-        self._update(self._prices.loc[start:end])
+        self._update(self._prices.loc[start:end], self._prices_full.loc[start:end])
 
     def display(self):
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -828,6 +828,46 @@ def test_group_stats_calc_stats(df):
     assert num_stats == num_unique_stats
 
 
+def test_group_stats_uses_each_series_own_calendar():
+    # GH #155: a NaN row in one series should not drop that date from the
+    # other series' individual stats
+    dates = pd.date_range("2020-01-31", periods=24, freq=ffn.core._MonthEnd)
+    np.random.seed(1)
+    sym1 = pd.Series(
+        100 * np.cumprod(1 + np.random.normal(0.01, 0.04, 24)), index=dates, name="SYM1"
+    )
+    sym2 = pd.Series(
+        100 * np.cumprod(1 + np.random.normal(0.01, 0.04, 24)), index=dates, name="SYM2"
+    )
+    # SYM2 missing for three months in the middle
+    sym2.iloc[9:12] = np.nan
+
+    gs = ffn.GroupStats(sym1, sym2)
+
+    # per-series stats match the single-series result
+    aae(gs["SYM1"].monthly_sharpe, ffn.PerformanceStats(sym1).monthly_sharpe, 9)
+    aae(gs["SYM1"].total_return, ffn.PerformanceStats(sym1).total_return, 9)
+    aae(
+        gs["SYM2"].monthly_sharpe, ffn.PerformanceStats(sym2.dropna()).monthly_sharpe, 9
+    )
+
+    # SYM1 keeps all of its own dates
+    assert len(gs["SYM1"].prices) == 24
+
+    # cross-sectional prices still use the common calendar
+    assert len(gs.prices) == 21
+
+    # date range slicing preserves the per-series calendar behaviour
+    gs.set_date_range(start=dates[3])
+    aae(
+        gs["SYM1"].monthly_sharpe,
+        ffn.PerformanceStats(sym1[dates[3]:]).monthly_sharpe,
+        9,
+    )
+    gs.set_date_range()
+    aae(gs["SYM1"].monthly_sharpe, ffn.PerformanceStats(sym1).monthly_sharpe, 9)
+
+
 def test_resample_returns(df):
     num_years = 30
     num_months = num_years * 12


### PR DESCRIPTION
Fixes #155.

## Problem

`GroupStats.__init__` does `merge(*prices).dropna()`, which drops a row for *every* column whenever *any* column is NaN on that date. Each column's `PerformanceStats` is then built from that intersection frame, so a gap in one series silently removes real observations from all the others. In the issue's data, SYM2 missing 2020-10/11/12 changed SYM1's `monthly_sharpe` from 3.0813 (single-column) to 2.9212 (multi-column) — with `total_return` unchanged, which is what makes it easy to miss (root-cause details in my comment on #155).

## Fix

Option 1 from the issue discussion: keep the merged/intersected frame for cross-sectional views (`prices`, correlations, plotting), but build each column's `PerformanceStats` from that column's own `.dropna()` series. `set_date_range` slices both frames the same way, so windowed stats keep the same behaviour. When every series shares a calendar, nothing changes.

Per-series stats now match what `PerformanceStats` returns for the same series alone. That is a behaviour change for data with unequal calendars — but the previous numbers were computed on silently truncated data, so I'd argue the new ones are the correct answer for both semantics.

## Testing

New regression test builds a 24-month, 2-column frame with a 3-month gap in one column, and pins: per-series stats equal single-series stats (for both the full range and after `set_date_range`), the gapped series drops only its own NaNs, and the cross-sectional `prices` frame still uses the common calendar. Fails on master, passes with the fix; full suite 45/45 green.
