### PR TITLE
docs: clarify rf price-vs-return series expectations

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -43,7 +43,10 @@ class PerformanceStats(object):
         * prices (Series): A price series.
         * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ used in various calculation. Should be
             expressed as a yearly (annualized) return if it is a float. Otherwise
-            rf should be a price series.
+            rf should be a *price* series — it is converted internally with
+            to_returns(). Note this differs from calc_sharpe and
+            calc_sortino_ratio, which take rf as a return series. Passing a
+            return series here silently behaves like rf=0.
 
     Attributes:
         * name (str): Name, derived from price series name
@@ -77,7 +80,8 @@ class PerformanceStats(object):
         Affects only this instance of the PerformanceStats.
 
         Args:
-            * rf (float): Annual `risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_
+            * rf (float, Series): Annual `risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_,
+                or a risk-free *price* series (not returns)
         """
         self.rf = rf
 
@@ -923,7 +927,8 @@ class GroupStats(dict):
         this GroupStats object.
 
         Args:
-            * rf (float, Series): Annual risk-free rate or risk-free rate price series
+            * rf (float, Series): Annual risk-free rate or risk-free rate *price*
+                series (not returns)
         """
 
         for key in self._names:
@@ -1410,7 +1415,8 @@ def calc_sharpe(returns, rf=0.0, nperiods=None, annualize=True):
 
     Args:
         * returns (Series, DataFrame): Input return series
-        * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed as a yearly (annualized) return or return series
+        * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed as a yearly (annualized) return or *return*
+            series (unlike PerformanceStats, which takes rf as a price series)
         * nperiods (int): Frequency of returns (252 for daily, 12 for monthly,
             etc.)
 


### PR DESCRIPTION
Follow-up to the discussion in #257 (also relevant to #85).

The rf parameter means different things at different entry points, and getting it wrong fails silently:

- `PerformanceStats` / `GroupStats.set_riskfree_rate` expect a **price** series — it's converted internally with `to_returns()`. Passing a return series makes the conversion produce ~0s, so stats are quietly computed with rf≈0 (the trap in #257: the Series path returned a *higher* Sharpe than the equivalent float).
- `calc_sharpe` / `calc_sortino_ratio` expect a **return** series.

This just makes the distinction explicit in the docstrings at all four entry points, including a note about the silent rf=0 behaviour. Docs only, no behaviour change; suite passes.
