### PR TITLE
Fix multi-period annualization inference

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2342,7 +2342,7 @@ def infer_nperiods(data, annualization_factor=None):
             whole_periods_str = freq[-1]
             num_str = freq[:-1]
             num = int(num_str)
-            return num * _whole_periods_str_to_nperiods(whole_periods_str, annualization_factor)
+            return _whole_periods_str_to_nperiods(whole_periods_str, annualization_factor) / num
     except KeyboardInterrupt:
         raise
     except BaseException:

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2349,7 +2349,7 @@ def infer_nperiods(data, annualization_factor=None):
             whole_periods_str = freq[-1]
             num_str = freq[:-1]
             num = int(num_str)
-            return _whole_periods_str_to_nperiods(whole_periods_str, annualization_factor) / num
+            return _whole_periods_str_to_nperiods(whole_periods_str, annualization_factor) / abs(num)
     except KeyboardInterrupt:
         raise
     except (TypeError, ValueError):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1227,4 +1227,8 @@ def test_infer_nperiods():
     returns_30min = minutely_30.squeeze()
     expected_sharpe = returns_30min.mean() / returns_30min.std(ddof=1) * np.sqrt(expected_30min_periods)
     assert np.allclose(returns_30min.calc_sharpe(), expected_sharpe)
+
+    descending_30min = minutely_30.sort_index(ascending=False).squeeze()
+    assert ffn.core.infer_nperiods(descending_30min) == expected_30min_periods
+    assert np.allclose(descending_30min.calc_sharpe(), expected_sharpe)
     assert ffn.core.infer_nperiods(not_known) is None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1037,5 +1037,10 @@ def test_infer_nperiods():
     assert ffn.core.infer_nperiods(secondly) == ffn.core.TRADING_DAYS_PER_YEAR * 24 * 60 * 60
     assert ffn.core.infer_nperiods(monthly) == 12
     assert ffn.core.infer_nperiods(yearly) == 1
-    assert ffn.core.infer_nperiods(minutely_30) == ffn.core.TRADING_DAYS_PER_YEAR * 24 * 60 * 30
+    expected_30min_periods = ffn.core.TRADING_DAYS_PER_YEAR * 24 * 60 / 30
+    assert ffn.core.infer_nperiods(minutely_30) == expected_30min_periods
+
+    returns_30min = minutely_30.squeeze()
+    expected_sharpe = returns_30min.mean() / returns_30min.std(ddof=1) * np.sqrt(expected_30min_periods)
+    assert np.allclose(returns_30min.calc_sharpe(), expected_sharpe)
     assert ffn.core.infer_nperiods(not_known) is None


### PR DESCRIPTION
## Summary

- divide the annual observation count by compound frequency multipliers instead of multiplying
- correct the existing `30min` period inference regression assertion
- verify the corrected inference flows through to annualized Sharpe calculations

For 30-minute data, `infer_nperiods` previously returned 10,886,400 periods per year instead of 12,096. That inflated annualized Sharpe and Sortino ratios by 30x.

Fixes #303.

## Validation

- `python -m pytest -q -ra` — 52 passed
- `ruff check ffn/core.py` — passed
- `git diff --check` — passed

AI assistance was used to identify the arithmetic inconsistency, draft the regression coverage, and run validation. The reproduction, one-line production fix, test expectations, and final diff were reviewed before publication.