### PR TITLE
fix: include the first period in Sortino downside deviation

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2367,7 +2367,7 @@ def calc_sortino_ratio(returns, rf=0.0, nperiods=None, annualize=True):
 
     er = returns.to_excess_returns(rf, nperiods=nperiods)
 
-    negative_returns = er[1:].clip(upper=0.0)
+    negative_returns = er.clip(upper=0.0)
     downside_deviation = np.sqrt((negative_returns**2).mean())
     with np.errstate(invalid="ignore", divide="ignore"):
         res = np.divide(er.mean(), downside_deviation)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -643,7 +643,7 @@ def test_calc_sortino_ratio(df):
 def test_calc_sortino_ratio_is_order_invariant():
     # Both the mean and the downside deviation are symmetric functions of the
     # sample, so reordering the same returns must not change the ratio.
-    idx = pd.date_range("2026-01-31", periods=4, freq="ME")
+    idx = pd.date_range("2026-01-31", periods=4, freq=ffn.core._MonthEnd)
     negative_first = pd.Series([-0.10, 0.02, 0.01, 0.03], index=idx)
     negative_last = pd.Series([0.02, 0.01, 0.03, -0.10], index=idx)
 
@@ -657,7 +657,7 @@ def test_calc_sortino_ratio_is_order_invariant():
 
 def test_calc_sortino_ratio_counts_first_period_downside():
     # A series whose only losing period comes first still has downside risk.
-    idx = pd.date_range("2026-01-31", periods=4, freq="ME")
+    idx = pd.date_range("2026-01-31", periods=4, freq=ffn.core._MonthEnd)
     returns = pd.Series([-0.10, 0.02, 0.01, 0.03], index=idx)
 
     assert np.isfinite(returns.calc_sortino_ratio(annualize=False))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -633,10 +633,44 @@ def test_calc_sortino_ratio(df):
     r = df.to_returns()
     a = r.calc_sortino_ratio(rf=rf, nperiods=p)
     er = r.to_excess_returns(rf, p)
-    negative_returns = er[1:].clip(upper=0.0)
+    negative_returns = er.clip(upper=0.0)
     downside_deviation = np.sqrt((negative_returns**2).mean())
     assert np.allclose(
         a, (er.mean() - rf) / downside_deviation * np.sqrt(p)
+    )
+
+
+def test_calc_sortino_ratio_is_order_invariant():
+    # Both the mean and the downside deviation are symmetric functions of the
+    # sample, so reordering the same returns must not change the ratio.
+    idx = pd.date_range("2026-01-31", periods=4, freq="ME")
+    negative_first = pd.Series([-0.10, 0.02, 0.01, 0.03], index=idx)
+    negative_last = pd.Series([0.02, 0.01, 0.03, -0.10], index=idx)
+
+    assert np.isclose(
+        negative_first.calc_sortino_ratio(annualize=False), -0.2
+    )
+    assert np.isclose(
+        negative_last.calc_sortino_ratio(annualize=False), -0.2
+    )
+
+
+def test_calc_sortino_ratio_counts_first_period_downside():
+    # A series whose only losing period comes first still has downside risk.
+    idx = pd.date_range("2026-01-31", periods=4, freq="ME")
+    returns = pd.Series([-0.10, 0.02, 0.01, 0.03], index=idx)
+
+    assert np.isfinite(returns.calc_sortino_ratio(annualize=False))
+
+
+def test_calc_sortino_ratio_ignores_leading_nan(df):
+    # Returns built from prices carry a leading NaN, which pandas already skips
+    # in both the mean and the downside deviation.
+    r = df.to_returns()
+
+    assert np.allclose(
+        r.calc_sortino_ratio(annualize=False),
+        r[1:].calc_sortino_ratio(annualize=False),
     )
 
 


### PR DESCRIPTION
calc_sortino_ratio computed its numerator over the whole excess return series but its denominator over er[1:], so the mean and the downside deviation were measured on different samples

Because both terms are symmetric functions of the sample, the ratio must not depend on ordering, but it did. For the returns [-0.10, 0.02, 0.01, 0.03] the function returned -inf, since dropping the first element removed the only losing period and collapsed the downside deviation to zero. Moving that same return to the end gave -0.173. The correct value is -0.2 either way

Returns derived from prices carry a leading NaN, which pandas already skips in both the mean and the downside deviation, so that path is unaffected

The existing test reimplemented the same er[1:] expression it was checking, so it asserted the implementation against itself and could not catch this