### PR TITLE
fix: put ulcer performance index on the same scale as the ulcer index

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2468,7 +2468,9 @@ def to_ulcer_performance_index(prices, rf=0.0, nperiods=None):
 
     er = prices.to_returns().to_excess_returns(rf, nperiods=nperiods)
 
-    return np.divide(er.mean(), prices.to_ulcer_index())
+    # to_ulcer_index is expressed in percentage points, so put the excess
+    # return on the same scale before dividing
+    return np.divide(er.mean() * 100.0, prices.to_ulcer_index())
 
 
 def resample_returns(returns, func, seed=0, num_trials=100):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -640,6 +640,44 @@ def test_calc_sortino_ratio(df):
     )
 
 
+def test_to_ulcer_index_is_in_percentage_points():
+    # 100 -> 90 -> 100 has drawdowns of 0%, -10%, 0%, so the ulcer index is
+    # sqrt(mean([0, 100, 0])) = sqrt(100 / 3)
+    idx = pd.date_range("2026-01-01", periods=3, freq="D")
+    prices = pd.Series([100.0, 90.0, 100.0], index=idx)
+
+    assert np.isclose(prices.to_ulcer_index(), np.sqrt(100 / 3))
+
+
+def test_to_ulcer_index_without_drawdown_is_zero():
+    idx = pd.date_range("2026-01-01", periods=4, freq="D")
+    prices = pd.Series([100.0, 101.0, 102.0, 103.0], index=idx)
+
+    assert np.isclose(prices.to_ulcer_index(), 0.0)
+
+
+def test_to_ulcer_performance_index_matches_ulcer_index_scale():
+    # The ulcer index is expressed in percentage points, so the excess return
+    # must be too. Mean excess return here is (-0.1 + 1/9) / 2 = 0.005555...,
+    # i.e. 0.5555...% against an ulcer index of sqrt(100 / 3).
+    idx = pd.date_range("2026-01-01", periods=3, freq="D")
+    prices = pd.Series([100.0, 90.0, 100.0], index=idx)
+
+    expected = (0.5555555555555556) / np.sqrt(100 / 3)
+
+    assert np.isclose(prices.to_ulcer_performance_index(), expected)
+
+
+def test_to_ulcer_performance_index_is_dimensionally_consistent():
+    idx = pd.date_range("2026-01-01", periods=8, freq="D")
+    prices = pd.Series([100.0, 110, 105, 120, 90, 95, 130, 125], index=idx)
+
+    upi = prices.to_ulcer_performance_index()
+    mean_excess_pct = prices.to_returns().mean() * 100
+
+    assert np.isclose(upi * prices.to_ulcer_index(), mean_excess_pct)
+
+
 def test_calmar_ratio(df):
     cagr = df.calc_cagr()
     mdd = df.calc_max_drawdown()


### PR DESCRIPTION
to_ulcer_index expresses drawdowns in percentage points, but to_ulcer_performance_index divided a decimal-fraction mean excess return by it, so every result came back 100x too small

For the prices [100, 110, 105, 120, 90, 95, 130, 125] the ulcer index is 11.70 and the mean excess return is 0.0476, giving 0.00407 where consistent units give 0.4066

Neither function had any test coverage, which is how the mismatch survived