### PR TITLE
Add pytest benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.benchmarks/
 .coverage
 .cache
 nosetests.xml
@@ -69,4 +70,3 @@ docs/source/_themes/klink/static/css
 
 #ipython notebook files
 .ipynb_checkpoints/
-

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 TMPREPO=/tmp/docs/ffn
 
-.PHONY: clean dist docs pages serve notebooks klink test lint fix develop
+.PHONY: clean dist docs pages serve notebooks klink test benchmark lint fix develop
 
 develop:
 	python -m pip install -e .[dev]
 
 test:
 	python -m pytest -vvv tests --cov=ffn --junitxml=python_junit.xml --cov-report=xml --cov-branch --cov-report term
+
+benchmark:
+	python -m pytest -vv benchmarks --benchmark-only
 
 lint:
 	python -m ruff check ffn docs/source/conf.py

--- a/benchmarks/test_core.py
+++ b/benchmarks/test_core.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import ffn
+
+
+@pytest.fixture(
+    scope="module",
+    params=[(252, 3), (2520, 10)],
+    ids=["1y-3-assets", "10y-10-assets"],
+)
+def prices(request):
+    periods, assets = request.param
+    rng = np.random.default_rng(42)
+    returns = rng.normal(0.0002, 0.01, size=(periods, assets))
+    return pd.DataFrame(
+        100.0 * np.exp(returns.cumsum(axis=0)),
+        index=pd.date_range("2010-01-01", periods=periods, freq="B"),
+        columns=[f"asset_{index}" for index in range(assets)],
+    )
+
+
+@pytest.mark.benchmark(group="returns")
+def test_to_returns(benchmark, prices):
+    result = benchmark(ffn.to_returns, prices)
+
+    assert result.shape == prices.shape
+
+
+@pytest.mark.benchmark(group="drawdown")
+def test_to_drawdown_series(benchmark, prices):
+    result = benchmark(ffn.to_drawdown_series, prices)
+
+    assert result.shape == prices.shape
+    assert result.max().max() <= 0.0
+
+
+@pytest.mark.benchmark(group="statistics")
+def test_calc_stats(benchmark, prices):
+    result = benchmark(ffn.calc_stats, prices)
+
+    assert result.stats.shape[1] == prices.shape[1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,13 @@ dev = [
     "build",
     "ruff",
     "pytest",
+    "pytest-benchmark",
     "pytest-cov",
     "twine",
 ]
 test = [
     "pytest",
+    "pytest-benchmark",
     "pytest-cov",
 ]
 


### PR DESCRIPTION
Add deterministic pytest-benchmark coverage for return conversion, drawdown calculation, and aggregate statistics across representative one-year and ten-year datasets.