### PR TITLE
Fix information ratio for DataFrame inputs

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1453,7 +1453,10 @@ def calc_information_ratio(returns, benchmark_returns):
     """
     Calculates the `Information ratio <https://www.investopedia.com/terms/i/informationratio.asp>`_ (or `from Wikipedia <http://en.wikipedia.org/wiki/Information_ratio>`_).
     """
-    diff_rets = returns - benchmark_returns
+    if isinstance(returns, pd.DataFrame) and isinstance(benchmark_returns, pd.Series):
+        diff_rets = returns.sub(benchmark_returns, axis="index")
+    else:
+        diff_rets = returns - benchmark_returns
     diff_std = diff_rets.std(ddof=1)
 
     if isinstance(diff_std, pd.Series):

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1456,6 +1456,12 @@ def calc_information_ratio(returns, benchmark_returns):
     diff_rets = returns - benchmark_returns
     diff_std = diff_rets.std(ddof=1)
 
+    if isinstance(diff_std, pd.Series):
+        result = pd.Series(0.0, index=diff_std.index)
+        valid = diff_std.notna() & diff_std.ne(0)
+        result.loc[valid] = np.divide(diff_rets.mean().loc[valid], diff_std.loc[valid])
+        return result
+
     if pd.isna(diff_std) or diff_std == 0:
         return 0.0
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -838,6 +838,24 @@ def test_calc_information_ratio_dataframe():
     pd.testing.assert_series_equal(actual, expected)
 
 
+def test_calc_information_ratio_dataframe_with_series_benchmark():
+    index = pd.date_range("2026-01-01", periods=4, freq="D")
+    returns = pd.DataFrame(
+        {
+            "fund_a": [0.03, 0.01, -0.02, 0.04],
+            "fund_b": [0.02, 0.02, -0.01, 0.03],
+        },
+        index=index,
+    )
+    benchmark = pd.Series([0.01, 0.0, -0.01, 0.02], index=index)
+
+    actual = returns.calc_information_ratio(benchmark)
+    difference = returns.sub(benchmark, axis="index")
+    expected = difference.mean() / difference.std(ddof=1)
+
+    pd.testing.assert_series_equal(actual, expected)
+
+
 def test_deannualize():
     res = ffn.deannualize(0.05, 252)
     assert np.allclose(res, np.power(1.05, 1 / 252.0) - 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -816,6 +816,28 @@ def test_calc_deflated_sharpe_ratio():
     aae(winner.calc_deflated_sharpe_ratio(sharpes), dsr)
 
 
+def test_calc_information_ratio_dataframe():
+    returns = pd.DataFrame(
+        {
+            "varying": [0.03, 0.01, -0.02, 0.04],
+            "constant": [0.01, 0.01, 0.01, 0.01],
+        }
+    )
+    benchmark = pd.DataFrame(
+        {
+            "varying": [0.01, 0.0, -0.01, 0.02],
+            "constant": [0.01, 0.01, 0.01, 0.01],
+        }
+    )
+
+    actual = returns.calc_information_ratio(benchmark)
+    difference = returns - benchmark
+    expected = difference.mean() / difference.std(ddof=1)
+    expected["constant"] = 0.0
+
+    pd.testing.assert_series_equal(actual, expected)
+
+
 def test_deannualize():
     res = ffn.deannualize(0.05, 252)
     assert np.allclose(res, np.power(1.05, 1 / 252.0) - 1)


### PR DESCRIPTION
## Problem

`calc_information_ratio` works for a Series, but a DataFrame's tracking-error calculation returns a Series of per-column standard deviations. The current scalar guard then asks pandas to coerce that Series to a single Boolean and raises `ValueError: The truth value of a Series is ambiguous`.

## Fix

Handle DataFrame results per column. Columns with valid tracking error return their information ratio; zero or missing tracking error returns `0.0`, matching the function's existing Series convention.

The regression covers both a varying active-return series and a zero-tracking-error series.

## Testing

- `python -m pytest -q` - 63 passed
- `python -m ruff check ffn docs/source/conf.py` - passed
- `git diff --check` - passed

AI assistance was used to scan for the untested DataFrame path and help draft the regression. I reproduced the failure in a clean Python 3.13 container and reviewed the implementation, expectations, and final diff before publication.
