### PR TITLE
fix: scale the information ratio by sqrt(n) in calc_prob_mom

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1474,8 +1474,10 @@ def calc_prob_mom(returns, other_returns):
     """
     # t.cdf expects a t-statistic, and the information ratio is mean / std.
     # Scaling by sqrt(n) turns it into one, so the probability reflects how
-    # much evidence there is rather than just the per-period edge.
-    n = len(returns)
+    # much evidence there is rather than just the per-period edge. n counts
+    # the aligned, non-NaN differentials actually used in the information
+    # ratio, not the raw series length.
+    n = (returns - other_returns).count()
     ir = returns.calc_information_ratio(other_returns)
     return t.cdf(ir * np.sqrt(n), n - 1)
 

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1472,7 +1472,12 @@ def calc_prob_mom(returns, other_returns):
     Source:
         http://cssanalytics.wordpress.com/2014/01/28/are-simple-momentum-strategies-too-dumb-introducing-probabilistic-momentum/ # NOQA
     """
-    return t.cdf(returns.calc_information_ratio(other_returns), len(returns) - 1)
+    # t.cdf expects a t-statistic, and the information ratio is mean / std.
+    # Scaling by sqrt(n) turns it into one, so the probability reflects how
+    # much evidence there is rather than just the per-period edge.
+    n = len(returns)
+    ir = returns.calc_information_ratio(other_returns)
+    return t.cdf(ir * np.sqrt(n), n - 1)
 
 
 def calc_total_return(prices):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -678,6 +678,51 @@ def test_to_ulcer_performance_index_is_dimensionally_consistent():
     assert np.isclose(upi * prices.to_ulcer_index(), mean_excess_pct)
 
 
+def _diff_series(n, mean=0.001, std=0.01):
+    # A return series against a flat benchmark, with the differential's mean and
+    # standard deviation pinned so the information ratio is exactly mean / std
+    rng = np.random.default_rng(0)
+    raw = rng.normal(0, 1, n)
+    raw = (raw - raw.mean()) / raw.std(ddof=1)
+    idx = pd.date_range("2020-01-01", periods=n, freq="D")
+    return (
+        pd.Series(mean + std * raw, index=idx),
+        pd.Series(np.zeros(n), index=idx),
+    )
+
+
+def test_calc_prob_mom_increases_with_sample_size():
+    """Test that the same per-period edge observed for longer gives more confidence"""
+    probs = []
+    for n in (10, 50, 250, 1000):
+        returns, benchmark = _diff_series(n)
+        assert np.isclose(returns.calc_information_ratio(benchmark), 0.1)
+        probs.append(returns.calc_prob_mom(benchmark))
+
+    for earlier, later in zip(probs, probs[1:]):
+        assert later > earlier
+
+    assert probs[0] < 0.7
+    assert probs[-1] > 0.99
+
+
+def test_calc_prob_mom_matches_one_sample_t_test():
+    """Test that the probability is the t CDF of the information ratio scaled by sqrt(n)"""
+    # 250 observations at an information ratio of 0.1 give a t statistic of
+    # 0.1 * sqrt(250) = 1.5811 on 249 degrees of freedom
+    returns, benchmark = _diff_series(250)
+
+    assert np.isclose(returns.calc_prob_mom(benchmark), 0.942442, atol=1e-6)
+
+
+def test_calc_prob_mom_without_an_edge_is_half():
+    """Test that a series compared against itself carries no information"""
+    idx = pd.date_range("2020-01-01", periods=100, freq="D")
+    returns = pd.Series(np.linspace(0.001, 0.002, 100), index=idx)
+
+    assert np.isclose(returns.calc_prob_mom(returns), 0.5)
+
+
 def test_calmar_ratio(df):
     cagr = df.calc_cagr()
     mdd = df.calc_max_drawdown()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -723,6 +723,20 @@ def test_calc_prob_mom_without_an_edge_is_half():
     assert np.isclose(returns.calc_prob_mom(returns), 0.5)
 
 
+def test_calc_prob_mom_ignores_unaligned_observations():
+    """Test that NaNs and non-overlapping dates don't count toward the sample size"""
+    returns, benchmark = _diff_series(250)
+    padded = returns.copy()
+    padded.iloc[0] = np.nan  # e.g. the leading NaN from to_returns()
+    short_benchmark = benchmark.iloc[:100]
+
+    # Only the 99 dates that are non-NaN in both series carry information, so
+    # the result must match the computation restricted to that window
+    expected = returns.iloc[1:100].calc_prob_mom(benchmark.iloc[1:100])
+
+    assert np.isclose(padded.calc_prob_mom(short_benchmark), expected)
+
+
 def test_calmar_ratio(df):
     cagr = df.calc_cagr()
     mdd = df.calc_max_drawdown()


### PR DESCRIPTION
calc_prob_mom passed an information ratio straight into t.cdf, which expects a t statistic. The information ratio is mean / std, so the sqrt(n) factor that turns it into one was missing

The probability therefore ignored how much evidence there was. At a per-period information ratio of 0.1 the function returned about 0.54 whether it saw 10 observations or 5000, where the correct values run from 0.62 to 1.0

The function had no test coverage