### PR TITLE
fix: correct frequency multiple annualization

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2347,7 +2347,7 @@ def infer_nperiods(data, annualization_factor=None):
             whole_periods_str = freq[-1]
             num_str = freq[:-1]
             num = int(num_str)
-            return num * _whole_periods_str_to_nperiods(whole_periods_str, annualization_factor)
+            return _whole_periods_str_to_nperiods(whole_periods_str, annualization_factor) / num
     except KeyboardInterrupt:
         raise
     except (TypeError, ValueError):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1170,5 +1170,5 @@ def test_infer_nperiods():
     assert ffn.core.infer_nperiods(secondly) == ffn.core.TRADING_DAYS_PER_YEAR * 24 * 60 * 60
     assert ffn.core.infer_nperiods(monthly) == 12
     assert ffn.core.infer_nperiods(yearly) == 1
-    assert ffn.core.infer_nperiods(minutely_30) == ffn.core.TRADING_DAYS_PER_YEAR * 24 * 60 * 30
+    assert ffn.core.infer_nperiods(minutely_30) == ffn.core.TRADING_DAYS_PER_YEAR * 24 * 60 / 30
     assert ffn.core.infer_nperiods(not_known) is None


### PR DESCRIPTION
Fixes infer_nperiods for interval multiples such as 30min by dividing whole-period annualization by the multiplier. Updates the regression assertion.\n\nValidation: git diff --check and py_compile passed. Focused pytest was unavailable locally because pytest is not installed.