### PR TITLE
Fix twelve_month_win_perc to use a full 12-month window

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -392,15 +392,11 @@ class PerformanceStats:
             # -1 here to account for first return that will be nan
             self.win_year_perc = len(yr[yr > 0]) / float(len(yr) - 1)
 
-            # need at least 1 year of monthly returns, i.e. 13 month end prices
+            # need enough monthly bins for at least one twelve-month window
             if mr.size > 12:
-                tot = 0
-                win = 0
-                for i in range(12, len(mr)):
-                    tot += 1
-                    if mp.iloc[i] / mp.iloc[i - 12] > 1:
-                        win += 1
-                self.twelve_month_win_perc = float(win) / tot
+                twelve_month_returns = (mp / mp.shift(12)).dropna()
+                if len(twelve_month_returns) > 0:
+                    self.twelve_month_win_perc = float((twelve_month_returns > 1).sum()) / len(twelve_month_returns)
 
         if r.index.to_series().diff().min() < pd.Timedelta("1097 days"):
             if len(yr) < 3:

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -392,13 +392,13 @@ class PerformanceStats:
             # -1 here to account for first return that will be nan
             self.win_year_perc = len(yr[yr > 0]) / float(len(yr) - 1)
 
-            # need at least 1 year of monthly returns
-            if mr.size > 11:
+            # need at least 1 year of monthly returns, i.e. 13 month end prices
+            if mr.size > 12:
                 tot = 0
                 win = 0
-                for i in range(11, len(mr)):
+                for i in range(12, len(mr)):
                     tot += 1
-                    if mp.iloc[i] / mp.iloc[i - 11] > 1:
+                    if mp.iloc[i] / mp.iloc[i - 12] > 1:
                         win += 1
                 self.twelve_month_win_perc = float(win) / tot
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -815,6 +815,12 @@ def test_twelve_month_win_perc_uses_twelve_month_window():
     stats = ffn.calc_stats(prices.iloc[:12]).stats
     assert pd.isnull(stats["twelve_month_win_perc"])
 
+    # Missing endpoint prices do not represent losing windows and are excluded.
+    full_index = pd.date_range("2020-01-31", periods=14, freq=ffn.core._MonthEnd)
+    prices = pd.Series(range(100, 113), index=full_index.delete(1))
+    stats = ffn.calc_stats(prices).stats
+    assert stats["twelve_month_win_perc"] == 1.0
+
 
 def test_calc_sharpe(df):
     x = pd.Series()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -765,6 +765,24 @@ def test_calc_stats(df):
     assert pd.isnull(stats["yearly_sharpe"])
 
 
+def test_twelve_month_win_perc_uses_twelve_month_window():
+    # 13 month end prices => exactly one full twelve month window,
+    # 2020-01-31 -> 2021-01-31, which returns 101 / 100 - 1 = +1%.
+    # The eleven month window 2020-01-31 -> 2020-12-31 is 99 / 100 - 1 = -1%,
+    # so measuring the wrong window flips the result.
+    index = pd.date_range("2020-01-31", periods=13, freq=ffn.core._MonthEnd)
+    prices = pd.Series([100.0] * 11 + [99.0, 101.0], index=index)
+
+    stats = ffn.calc_stats(prices).stats
+
+    assert stats["twelve_month_win_perc"] == 1.0
+
+    # 12 month end prices are only eleven monthly returns, which is not
+    # enough for a twelve month window
+    stats = ffn.calc_stats(prices.iloc[:12]).stats
+    assert pd.isnull(stats["twelve_month_win_perc"])
+
+
 def test_calc_sharpe(df):
     x = pd.Series()
     assert np.isnan(x.calc_sharpe())


### PR DESCRIPTION
## Summary

- measure `twelve_month_win_perc` over a full 12-month interval
- require 13 month-end prices before calculating the first 12-month window
- add a regression test whose 11-month and 12-month outcomes differ

## Problem and reproduction

The existing loop starts at index 11 and compares `mp.iloc[i]` with `mp.iloc[i - 11]`, so the metric labelled Win 12m actually measures 11-month intervals.

A 13-point monthly series ending with `... 99, 101` reproduces the difference: January-to-December is negative (`99 / 100`), while January-to-January is positive (`101 / 100`). The regression test verifies that the metric uses the latter full-year interval and remains unavailable with only 12 month-end prices.

## Tests

- `python -m pytest tests/test_core.py -k twelve_month_win_perc -q` ? 1 passed
- `python -m pytest tests/test_core.py -q` ? 56 passed
- `git diff --check upstream/master...HEAD`
