### PR TITLE
Fix GroupStats date range reset for staggered calendars

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -831,8 +831,10 @@ class GroupStats(dict):
                 "have same name! Please provide unique names",
             )
 
-        self._start = self._prices.index[0]
-        self._end = self._prices.index[-1]
+        # Keep the full available range so set_date_range() can restore
+        # observations outside the shared cross-sectional calendar.
+        self._start = self._prices_full.first_valid_index()
+        self._end = self._prices_full.last_valid_index()
         # calculate stats for entire series
         self._update(self._prices, self._prices_full)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1001,6 +1001,20 @@ def test_group_stats_uses_each_series_own_calendar():
     aae(gs["SYM1"].monthly_sharpe, ffn.PerformanceStats(sym1).monthly_sharpe, 9)
 
 
+def test_group_stats_date_range_reset_restores_full_calendars():
+    dates = pd.date_range("2020-01-01", periods=8, freq="D")
+    early = pd.Series(range(100, 105), index=dates[:5], name="EARLY")
+    late = pd.Series(range(200, 206), index=dates[2:], name="LATE")
+
+    gs = ffn.GroupStats(early, late)
+    gs.set_date_range()
+
+    assert gs["EARLY"].start == dates[0]
+    assert gs["EARLY"].end == dates[4]
+    assert gs["LATE"].start == dates[2]
+    assert gs["LATE"].end == dates[-1]
+
+
 def test_resample_returns(df):
     num_years = 30
     num_months = num_years * 12


### PR DESCRIPTION
## Summary

- preserve the full per-series date range in `GroupStats`
- make `set_date_range()` without arguments restore observations outside the shared calendar
- add regression coverage for series with staggered start and end dates

## Tests

- `python -m pytest -q tests` (63 passed)
- `ruff check ffn`
- `ruff format --check ffn`