### PR TITLE
Fix memoize with keyword-only refresh flags

### DIFF
--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -15,8 +15,9 @@ def _memoize(func, *args, **kw):
     refresh_kw = func.mrefresh_keyword
 
     # kw is not always set - check args
-    if refresh_kw in func.__code__.co_varnames:
-        refresh_idx = func.__code__.co_varnames.index(refresh_kw)
+    positional_vars = func.__code__.co_varnames[: func.__code__.co_argcount]
+    if refresh_kw in positional_vars:
+        refresh_idx = positional_vars.index(refresh_kw)
         if refresh_idx < len(args) and args[refresh_idx]:
             refresh = True
 

--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -15,8 +15,10 @@ def _memoize(func, *args, **kw):
     refresh_kw = func.mrefresh_keyword
 
     # kw is not always set - check args
-    if refresh_kw in func.__code__.co_varnames and args[func.__code__.co_varnames.index(refresh_kw)]:
-        refresh = True
+    if refresh_kw in func.__code__.co_varnames:
+        refresh_idx = func.__code__.co_varnames.index(refresh_kw)
+        if refresh_idx < len(args) and args[refresh_idx]:
+            refresh = True
 
     # check in kw if not already set above
     if not refresh and refresh_kw in kw and kw[refresh_kw]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,6 +17,19 @@ def test_memoize_handles_keyword_only_refresh():
     assert cached("value") == 1
 
 
+def test_memoize_does_not_treat_varargs_as_keyword_only_refresh():
+    calls = []
+
+    @utils.memoize
+    def cached(value, *items, mrefresh=False):
+        calls.append((value, items, mrefresh))
+        return len(calls)
+
+    assert cached("value", True) == 1
+    assert cached("value", True) == 1
+    assert cached("value", True, mrefresh=True) == 2
+
+
 def test_parse_args():
     actual = utils.parse_arg('a,b,c')
     assert actual == ['a', 'b', 'c']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,21 @@ import ffn.utils as utils
 import pandas as pd
 
 
+def test_memoize_handles_keyword_only_refresh():
+    calls = []
+
+    @utils.memoize
+    def cached(value, *, mrefresh=False):
+        calls.append((value, mrefresh))
+        return len(calls)
+
+    assert cached("value") == 1
+    assert cached("value") == 1
+    assert cached("value", mrefresh=True) == 2
+    assert cached("value", mrefresh=True) == 3
+    assert cached("value") == 1
+
+
 def test_parse_args():
     actual = utils.parse_arg('a,b,c')
     assert actual == ['a', 'b', 'c']
@@ -106,4 +121,3 @@ def test_as_format():
     assert actual.loc['msft', 'aapl'] == '218.24'
     assert actual.loc['aapl', 'msft'] == '23.39'
     assert actual.loc['msft', 'msft'] == '23.40'
-


### PR DESCRIPTION
## Summary

- avoid indexing past positional arguments when the memoized function defines a keyword-only refresh flag
- preserve normal cache hits and forced refresh behavior
- add regression coverage for omitted and repeated keyword-only `mrefresh` calls

## Tests

- `python -m pytest -q tests` (63 passed)
- `ruff check ffn`
- `ruff format --check ffn`