### PR TITLE
Return nan from calc_deflated_sharpe_ratio when the series has no dispersion

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2570,8 +2570,12 @@ def calc_deflated_sharpe_ratio(returns, trial_sharpe_ratios, rf=0.0, nperiods=No
     # input carrying no information about one. Compare against the resolution of a
     # float at the scale of the data, so a genuinely low-volatility series still gets
     # a number.
+    # The residue grows with the number of terms summed, so the floor is n eps rather
+    # than eps: measured at most 1.96 eps x scale over constant series spanning values
+    # 1e-7..1e3 and lengths 3..10000, while a real series with sigma=1e-12 sits more
+    # than ten orders of magnitude above n eps x scale.
     scale = float(np.abs(returns).max())
-    if returns.std(ddof=1) <= np.finfo(float).eps * scale:
+    if not returns.std(ddof=1) > n * np.finfo(float).eps * scale:
         return np.nan
 
     sr0 = calc_expected_max_sharpe(len(trials), trials.std(ddof=1))

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2562,6 +2562,18 @@ def calc_deflated_sharpe_ratio(returns, trial_sharpe_ratios, rf=0.0, nperiods=No
     if n < 3 or pd.isnull(sr):
         return np.nan
 
+    # A series with no dispersion has no Sharpe ratio, but it does not arrive here as
+    # a nan: the standard deviation of a constant series is floating-point residue
+    # rather than an exact zero, so a flat +0.1% series divides out to a Sharpe of
+    # 4.6e15 -- finite, and therefore past the check above and every isfinite guard
+    # after it. Deflating that returns 1.0, i.e. certainty of a real edge, for the one
+    # input carrying no information about one. Compare against the resolution of a
+    # float at the scale of the data, so a genuinely low-volatility series still gets
+    # a number.
+    scale = float(np.abs(returns).max())
+    if returns.std(ddof=1) <= np.finfo(float).eps * scale:
+        return np.nan
+
     sr0 = calc_expected_max_sharpe(len(trials), trials.std(ddof=1))
 
     # Probabilistic Sharpe ratio of the winner against that hurdle,

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2562,20 +2562,13 @@ def calc_deflated_sharpe_ratio(returns, trial_sharpe_ratios, rf=0.0, nperiods=No
     if n < 3 or pd.isnull(sr):
         return np.nan
 
-    # A series with no dispersion has no Sharpe ratio, but it does not arrive here as
-    # a nan: the standard deviation of a constant series is floating-point residue
-    # rather than an exact zero, so a flat +0.1% series divides out to a Sharpe of
-    # 4.6e15 -- finite, and therefore past the check above and every isfinite guard
-    # after it. Deflating that returns 1.0, i.e. certainty of a real edge, for the one
-    # input carrying no information about one. Compare against the resolution of a
-    # float at the scale of the data, so a genuinely low-volatility series still gets
-    # a number.
-    # The residue grows with the number of terms summed, so the floor is n eps rather
-    # than eps: measured at most 1.96 eps x scale over constant series spanning values
-    # 1e-7..1e3 and lengths 3..10000, while a real series with sigma=1e-12 sits more
-    # than ten orders of magnitude above n eps x scale.
-    scale = float(np.abs(returns).max())
-    if not returns.std(ddof=1) > n * np.finfo(float).eps * scale:
+    # Use excess-return range instead of standard deviation so constant inputs are
+    # not obscured by accumulated rounding error. The bounded tolerance also handles
+    # cancellation residue from a varying risk-free return without growing with n.
+    excess_returns = returns.to_excess_returns(rf, nperiods=nperiods)
+    spread = float(excess_returns.max() - excess_returns.min())
+    scale = max(float(np.abs(returns).max()), float(np.abs(excess_returns).max()))
+    if not spread > 4 * np.finfo(float).eps * scale:
         return np.nan
 
     sr0 = calc_expected_max_sharpe(len(trials), trials.std(ddof=1))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -838,6 +838,20 @@ def test_calc_deflated_sharpe_ratio_zero_dispersion():
     quiet = pd.Series(np.random.default_rng(1).normal(0, 1e-8, 250))
     assert 0 <= ffn.calc_deflated_sharpe_ratio(quiet, sharpes) <= 1
 
+    # A long, quiet series around a nonzero mean still has real dispersion. The
+    # zero-dispersion threshold must not grow with the sample size and swallow it.
+    quiet_nonzero = pd.Series(1.0 + np.random.default_rng(1).normal(0, 1e-12, 5000))
+    assert 0 <= ffn.calc_deflated_sharpe_ratio(quiet_nonzero, sharpes, nperiods=252) <= 1
+
+    # Dispersion is measured after subtracting a series risk-free rate, matching the
+    # returns used to calculate Sharpe. Check both directions of that distinction.
+    rf = pd.Series(np.linspace(0.0001, 0.0002, 250))
+    constant_excess = rf + 0.001
+    assert np.isnan(ffn.calc_deflated_sharpe_ratio(constant_excess, sharpes, rf=rf, nperiods=252))
+
+    variable_excess = pd.Series([0.001] * 250)
+    assert 0 <= ffn.calc_deflated_sharpe_ratio(variable_excess, sharpes, rf=rf, nperiods=252) <= 1
+
 
 def test_deannualize():
     res = ffn.deannualize(0.05, 252)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -816,6 +816,23 @@ def test_calc_deflated_sharpe_ratio():
     aae(winner.calc_deflated_sharpe_ratio(sharpes), dsr)
 
 
+def test_calc_deflated_sharpe_ratio_zero_dispersion():
+    sharpes = [0.5, 1.0, 1.5, 2.0]
+
+    # A constant series has no dispersion, so no Sharpe ratio and no deflated one.
+    # Its standard deviation is floating-point residue rather than an exact zero, so
+    # the ratio comes out finite (~4.6e15) and reaches the deflation arithmetic, which
+    # answered 1.0 -- certainty of an edge, from the one input that cannot show one.
+    flat = pd.Series([0.001] * 250)
+    assert np.isnan(ffn.calc_deflated_sharpe_ratio(flat, sharpes))
+    assert np.isnan(ffn.calc_deflated_sharpe_ratio(pd.Series([0.0] * 250), sharpes))
+
+    # The guard is relative to the scale of the data: a real but very quiet series
+    # still gets a number.
+    quiet = pd.Series(np.random.default_rng(1).normal(0, 1e-8, 250))
+    assert 0 <= ffn.calc_deflated_sharpe_ratio(quiet, sharpes) <= 1
+
+
 def test_deannualize():
     res = ffn.deannualize(0.05, 252)
     assert np.allclose(res, np.power(1.05, 1 / 252.0) - 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -823,8 +823,14 @@ def test_calc_deflated_sharpe_ratio_zero_dispersion():
     # Its standard deviation is floating-point residue rather than an exact zero, so
     # the ratio comes out finite (~4.6e15) and reaches the deflation arithmetic, which
     # answered 1.0 -- certainty of an edge, from the one input that cannot show one.
-    flat = pd.Series([0.001] * 250)
-    assert np.isnan(ffn.calc_deflated_sharpe_ratio(flat, sharpes))
+    # Checked across values and lengths, not at one point: the residue depends on both,
+    # so a guard calibrated on a single series passes while still leaking elsewhere.
+    for value in (1e-7, 1e-4, 0.001, 0.01, 1.0, 100.0):
+        for n in (3, 10, 250, 5000):
+            flat = pd.Series([value] * n)
+            assert np.isnan(
+                ffn.calc_deflated_sharpe_ratio(flat, sharpes)
+            ), f"leaked at value={value}, n={n}"
     assert np.isnan(ffn.calc_deflated_sharpe_ratio(pd.Series([0.0] * 250), sharpes))
 
     # The guard is relative to the scale of the data: a real but very quiet series


### PR DESCRIPTION
Follow-up to #311, fixing a hole I left in it.

`calc_deflated_sharpe_ratio` returns **1.0** — certainty of a real edge — for a constant return series:

```python
>>> ffn.calc_deflated_sharpe_ratio(pd.Series([0.001] * 250), [0.5, 1.0, 1.5, 2.0])
1.0
```

A constant series has no dispersion and therefore no Sharpe ratio, but it does not arrive at the deflation arithmetic as a `nan`. Its standard deviation is floating-point residue (2.2e-19) rather than an exact zero, so `calc_sharpe` divides out to 4.6e15 — finite, and so past the `pd.isnull(sr)` check and every `isfinite` guard downstream. `variance_adj` then comes out large and positive, and the normal CDF saturates at 1.0.

That is the wrong direction for this statistic in particular: it exists to catch results that are too good to be true, so the series least able to support a claim should not be the one it is most confident about. A flat equity curve is not exotic — a strategy that never trades, a fixed-yield leg, or a backtest bug that writes the same return every period all produce one.

**The fix** compares dispersion against the resolution of a float at the scale of the data rather than against zero, because the residue sits near `eps` and a plain `> 0` test does not see it. A genuinely quiet series is unaffected: the test asserts that a normal series with `sigma=1e-8` still gets a number.

**Verification**

- Parity on 40 random series spanning `n=50..800`, `sigma=1e-4..1e-1` and 1..60 trials: every legitimate value is bit-identical before and after, so only the degenerate input changes.
- New test covers the constant series, the all-zero series, and the quiet-but-real series.
- I checked that the new test actually fails against the unfixed source rather than merely passing alongside it.
- Full suite green (63 passed). `ruff check` and `ruff format --check` clean on `ffn/core.py`; `tests/test_core.py` has 6 pre-existing ruff findings on master, unchanged in count by this commit.

For what it is worth, I found this by running the same degenerate inputs through three implementations of the formula and noticing they disagreed: a reference implementation of mine raises on zero variance, another returns `nan`, and this one returned 1.0. The parity check I ran when writing #311 compared values on well-behaved data only, which is exactly where the three agree.
