### PR TITLE
Support custom GroupStats annualization

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -792,6 +792,7 @@ class GroupStats(dict):
 
     Args:
         * prices (Series): Multiple price series to be compared.
+        * annualization_factor (float): Annualization factor used for each series.
 
     Attributes:
         * stats (DataFrame): Dataframe containing stats for each
@@ -803,7 +804,8 @@ class GroupStats(dict):
 
     """
 
-    def __init__(self, *prices):
+    def __init__(self, *prices, annualization_factor=None):
+        self._annualization_factor_override = annualization_factor
         names = []
         for p in prices:
             if isinstance(p, pd.DataFrame):
@@ -857,7 +859,7 @@ class GroupStats(dict):
             full_data = data
         for c in data.columns:
             prc = full_data[c].dropna()
-            self[c] = PerformanceStats(prc)
+            self[c] = PerformanceStats(prc, annualization_factor=self._annualization_factor_override)
 
     def _stats(self):
         stats = [
@@ -1246,7 +1248,7 @@ def calc_perf_stats(prices, risk_free_rate=0.0, annualization_factor=252):
     return PerformanceStats(prices, rf=risk_free_rate, annualization_factor=annualization_factor)
 
 
-def calc_stats(prices):
+def calc_stats(prices, annualization_factor=None):
     """
     Calculates performance stats of a given object.
 
@@ -1256,11 +1258,15 @@ def calc_stats(prices):
 
     Args:
         * prices (Series, DataFrame): Set of prices
+        * annualization_factor (float): Annualization factor used in calculations
     """
     if isinstance(prices, pd.Series):
-        return PerformanceStats(prices)
+        return PerformanceStats(prices, annualization_factor=annualization_factor)
     elif isinstance(prices, pd.DataFrame):
-        return GroupStats(*[prices[x] for x in prices.columns])
+        return GroupStats(
+            *[prices[x] for x in prices.columns],
+            annualization_factor=annualization_factor,
+        )
     else:
         raise NotImplementedError("Unsupported type")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1071,6 +1071,21 @@ def test_group_stats_calc_stats(df):
     assert num_stats == num_unique_stats
 
 
+def test_calc_stats_annualization_factor(df):
+    prices = df[["AAPL", "MSFT"]]
+    stats = prices.calc_stats(annualization_factor=365)
+
+    assert stats["AAPL"].annualization_factor == 365
+    assert stats["MSFT"].annualization_factor == 365
+
+    stats.set_date_range(start=prices.index[10])
+    assert stats["AAPL"].annualization_factor == 365
+    assert stats["MSFT"].annualization_factor == 365
+
+    single_stats = prices["AAPL"].calc_stats(annualization_factor=365)
+    assert single_stats.annualization_factor == 365
+
+
 def test_group_stats_uses_each_series_own_calendar():
     # GH #155: a NaN row in one series should not drop that date from the
     # other series' individual stats


### PR DESCRIPTION
GroupStats and calc_stats now accept and propagate a custom annualization factor to each PerformanceStats instance. The override is retained when GroupStats recalculates after a date-range change.

Previously this setting was available only when constructing PerformanceStats directly, so DataFrame and grouped statistics silently used inferred or default annualization.

This supports markets that operate on calendars other than 252 trading days per year.

Fixes #33