### PR TITLE
Preserve first return in performance stats

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1203,10 +1203,22 @@ def to_price_index(returns, start=100):
         return cp
 
     # No leading NaN – prepend ``start`` so the first price equals start.
+    start_index = cp.index[0]
+    if isinstance(cp.index, pd.DatetimeIndex):
+        frequency = cp.index.freq
+        if frequency is None and len(cp.index) >= 3:
+            frequency = pd.infer_freq(cp.index)
+        if frequency is not None:
+            start_index -= pd.tseries.frequencies.to_offset(frequency)
+        elif len(cp.index) > 1:
+            start_index -= cp.index[1] - cp.index[0]
+        else:
+            start_index -= pd.Timedelta(days=1)
+
     if isinstance(cp, pd.DataFrame):
-        start_row = pd.DataFrame({c: [start] for c in cp.columns}, index=[cp.index[0]])
+        start_row = pd.DataFrame({c: [start] for c in cp.columns}, index=[start_index])
     else:
-        start_row = pd.Series([start], index=[cp.index[0]], name=cp.name)
+        start_row = pd.Series([start], index=[start_index], name=cp.name)
 
     return pd.concat([start_row, cp])
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -142,6 +142,22 @@ def test_to_price_index(df):
     aae(actual["C"].iloc[9], 1.012, 3)
 
 
+def test_to_price_index_preserves_first_return_in_stats():
+    returns = pd.Series(
+        [0.10, -0.05, 0.02, 0.03],
+        index=pd.date_range("2024-01-08", periods=4, freq="B"),
+        name="strategy",
+    )
+
+    prices = returns.to_price_index()
+    stats = prices.calc_stats()
+
+    assert prices.index.is_unique
+    assert np.allclose(stats.returns.dropna(), returns)
+    assert np.isclose(stats.daily_mean, returns.mean() * 252)
+    assert np.isclose(stats.total_return, np.prod(1 + returns) - 1)
+
+
 def test_rebase(df):
     data = df
     actual = data.rebase()


### PR DESCRIPTION
Datetime-indexed returns converted with to_price_index now receive a unique baseline at the preceding period. This lets strategy returns flow through returns.to_price_index().calc_stats() without losing the first observation.

Previously the baseline and first compounded price shared a timestamp. PerformanceStats resampled those duplicate timestamps to one daily value, silently omitting the first return from daily statistics.

The regression test verifies a unique index, complete stored returns, annualized daily mean, and total return.

Fixes #85