### PR TITLE
Add calc_fdr_hurdle, a bootstrap hurdle for the multiplicity of a strategy search

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2608,6 +2608,121 @@ def calc_deflated_sharpe_ratio(returns, trial_sharpe_ratios, rf=0.0, nperiods=No
     return scipy.stats.norm.cdf((sr - sr0) * np.sqrt(n - 1) / np.sqrt(variance_adj))
 
 
+def calc_fdr_hurdle(returns, target_fdr=0.05, n_boot=1000, seed=0, grid_step=0.05):
+    """
+    Calculates the t-statistic hurdle that a strategy search implies at a chosen
+    false discovery rate, following `Harvey and Liu (2020)
+    <https://doi.org/10.1111/jofi.12951>`_.
+
+    There is no universal cutoff. The bar a candidate must clear depends on how
+    many candidates were tried and on how correlated they were, so it has to be
+    derived from the search itself rather than read off a table. Pass the return
+    series of **every** trial that was evaluated, one per column: the count and
+    the joint behaviour of those columns set the hurdle, and a panel of only the
+    survivors will understate it.
+
+    The null is built by demeaning each column and resampling the time index,
+    drawing the **same** periods for every column so that cross-trial
+    correlation survives into the null. Every trial is treated as null when
+    counting expected false discoveries, which is conservative in the same way
+    Benjamini-Hochberg is with ``m0 = m``. The hurdle returned is the smallest
+    one for which the target also holds at every stricter hurdle, so it cannot
+    land on a dip in a noisy curve.
+
+    Because the alternative is never represented, this says nothing about
+    discoveries that were *missed*; it bounds false ones only.
+
+    Columns with no dispersion are dropped before the hurdle is computed. Such a
+    column has no t-statistic, yet floating-point residue gives it an enormous
+    finite one, and it would otherwise be counted as the strongest trial in the
+    search. Dropping changes the trial count, which is what sets the hurdle, so
+    the result is the hurdle for the trials that carry information.
+
+    Source: Harvey, C. R. and Liu, Y. (2020), "False (and Missed) Discoveries in
+    Financial Economics", Journal of Finance, 75(5), 2503-2553.
+
+    Args:
+        * returns (DataFrame): Return series of all evaluated trials, one
+            column per trial, sharing a time index.
+        * target_fdr (float): Share of the discoveries that may be false.
+            Harvey and Liu use 0.05.
+        * n_boot (int): Number of bootstrap draws used to build the null.
+        * seed (int): Seed for the bootstrap, so the hurdle is reproducible.
+        * grid_step (float): Resolution of the hurdle grid in t units.
+
+    Returns:
+        * float -- the |t| a trial must reach. Compare it against each column's
+          own t-statistic; columns at or above it are the discoveries. When no
+          trial clears the target the value sits just above the largest observed
+          |t|, marking that the panel holds no discovery rather than describing
+          the multiplicity.
+
+    """
+    if not 0.0 < target_fdr < 1.0:
+        raise ValueError("target_fdr must be between 0 and 1")
+    if n_boot < 100:
+        raise ValueError("n_boot below 100 makes the null too coarse to trust")
+    if grid_step <= 0:
+        raise ValueError("grid_step must be positive")
+
+    x = pd.DataFrame(returns).dropna(axis=0, how="any")
+    n, m = x.shape
+    if m < 2:
+        raise ValueError("need at least 2 trials; the hurdle comes from the multiplicity")
+    if n < 3:
+        return np.nan
+
+    values = x.to_numpy(dtype=float)
+
+    # A column with no dispersion has no t-statistic, but it does not arrive here as a
+    # nan: the standard deviation of a constant series is floating-point residue rather
+    # than an exact zero, so a flat column divides out to something enormous but finite
+    # and would be counted as the strongest trial in the search. Compare against the
+    # resolution of a float at the scale of that column, so a genuinely low-volatility
+    # trial still gets a number, and drop only the columns carrying no information.
+    scale = np.max(np.abs(values), axis=0)
+    keep = values.std(axis=0, ddof=1) > n * np.finfo(float).eps * np.maximum(scale, 1.0)
+    if not keep.any():
+        return np.nan
+    dropped = m - int(keep.sum())
+    values = values[:, keep]
+    m = values.shape[1]
+    if m < 2:
+        raise ValueError(f"only {m} of {m + dropped} trials carry dispersion; need 2")
+
+    root_n = np.sqrt(n)
+    obs = np.sort(np.abs(values.mean(axis=0) / (values.std(axis=0, ddof=1) / root_n)))
+
+    demeaned = values - values.mean(axis=0)
+    rng = np.random.default_rng(seed)
+    null = np.empty(n_boot * m, dtype=float)
+    for b in range(n_boot):
+        idx = rng.integers(0, n, size=n)  # one draw shared by every column
+        sample = demeaned[idx]
+        sd = sample.std(axis=0, ddof=1)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            tb = np.abs(sample.mean(axis=0) / (sd / root_n))
+        null[b * m : (b + 1) * m] = np.where(np.isfinite(tb), tb, 0.0)
+    null.sort()
+
+    grid = np.arange(0.0, max(4.0, obs[-1] + 0.5) + grid_step, grid_step)
+    # Expected false discoveries at each hurdle, and the discoveries actually seen.
+    expected_false = (len(null) - np.searchsorted(null, grid, side="left")) / n_boot
+    discoveries = m - np.searchsorted(obs, grid, side="left")
+    with np.errstate(divide="ignore", invalid="ignore"):
+        fdr = np.where(discoveries > 0, np.minimum(1.0, expected_false / discoveries), 0.0)
+
+    # Walk down from the strictest hurdle and keep the smallest one whose whole tail
+    # still meets the target: a single dip in the curve must not be enough to pass.
+    hurdle = grid[-1]
+    tail_max = 0.0
+    for h, f in zip(grid[::-1], fdr[::-1]):
+        tail_max = max(tail_max, f)
+        if tail_max <= target_fdr:
+            hurdle = h
+    return float(hurdle)
+
+
 def resample_returns(returns, func, seed=0, num_trials=100):
     """
     Resample the returns and calculate any statistic on every new sample.
@@ -2686,6 +2801,7 @@ def extend_pandas():
     PandasObject.calc_sharpe = calc_sharpe
     PandasObject.calc_sharpe_ratio = calc_sharpe
     PandasObject.calc_deflated_sharpe_ratio = calc_deflated_sharpe_ratio
+    PandasObject.calc_fdr_hurdle = calc_fdr_hurdle
     PandasObject.to_excess_returns = to_excess_returns
     PandasObject.to_ulcer_index = to_ulcer_index
     PandasObject.to_ulcer_performance_index = to_ulcer_performance_index

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1,4 +1,5 @@
 import random
+import warnings
 
 import matplotlib
 import numpy as np
@@ -2611,8 +2612,7 @@ def calc_deflated_sharpe_ratio(returns, trial_sharpe_ratios, rf=0.0, nperiods=No
 def calc_fdr_hurdle(returns, target_fdr=0.05, n_boot=1000, seed=0, grid_step=0.05):
     """
     Calculates the t-statistic hurdle that a strategy search implies at a chosen
-    false discovery rate, following `Harvey and Liu (2020)
-    <https://doi.org/10.1111/jofi.12951>`_.
+    false discovery rate, as a bootstrap plug-in estimate.
 
     There is no universal cutoff. The bar a candidate must clear depends on how
     many candidates were tried and on how correlated they were, so it has to be
@@ -2623,14 +2623,37 @@ def calc_fdr_hurdle(returns, target_fdr=0.05, n_boot=1000, seed=0, grid_step=0.0
 
     The null is built by demeaning each column and resampling the time index,
     drawing the **same** periods for every column so that cross-trial
-    correlation survives into the null. Every trial is treated as null when
-    counting expected false discoveries, which is conservative in the same way
-    Benjamini-Hochberg is with ``m0 = m``. The hurdle returned is the smallest
-    one for which the target also holds at every stricter hurdle, so it cannot
-    land on a dip in a noisy curve.
+    correlation survives into the null. At a hurdle ``h`` the expected number of
+    false discoveries is read off that null and divided by the discoveries
+    actually observed at ``h``. Every trial is treated as null in that numerator,
+    conservative in the same way Benjamini-Hochberg is with ``m0 = m``. The
+    hurdle returned is the smallest one for which the target also holds at every
+    stricter hurdle, so it cannot land on a dip in a noisy curve.
+
+    What this estimates is ``E[V] / R``, expected false discoveries over the
+    realized discovery count. That is not ``E[V / R]``, and the two do not agree
+    in general. Nor is it the procedure of Harvey and Liu (2020), which ranks
+    t-statistics in an outer bootstrap, assigns alternatives from a supplied
+    share of true strategies, and averages the realized ``FP / (FP + TP)`` in an
+    inner bootstrap - inputs this signature does not take. Their paper is why a
+    hurdle of this shape is worth having; the number here is not theirs.
+
+    The comparison is two-sided: trials are ranked by ``|t|``, so a strongly
+    negative strategy counts as a discovery too. A caller screening for
+    outperformance should compare the hurdle against the positive-t columns
+    only.
 
     Because the alternative is never represented, this says nothing about
     discoveries that were *missed*; it bounds false ones only.
+
+    The panel is reduced to complete cases: a period is dropped unless every
+    trial has an observation there. The bootstrap draws one period for all
+    columns at once, which is what keeps cross-trial correlation in the null,
+    and there is nothing to draw where a column is missing. Trials with
+    staggered histories can lose most of the sample this way, which moves the
+    hurdle, so the number of periods kept is reported in a warning whenever any
+    row goes. Align the panel yourself if you would rather make that trade-off
+    explicitly.
 
     Columns with no dispersion are dropped before the hurdle is computed. Such a
     column has no t-statistic, yet floating-point residue gives it an enormous
@@ -2638,14 +2661,15 @@ def calc_fdr_hurdle(returns, target_fdr=0.05, n_boot=1000, seed=0, grid_step=0.0
     search. Dropping changes the trial count, which is what sets the hurdle, so
     the result is the hurdle for the trials that carry information.
 
-    Source: Harvey, C. R. and Liu, Y. (2020), "False (and Missed) Discoveries in
+    Related: Benjamini, Y. and Hochberg, Y. (1995), "Controlling the False
+    Discovery Rate", Journal of the Royal Statistical Society B, 57(1), 289-300,
+    and Harvey, C. R. and Liu, Y. (2020), "False (and Missed) Discoveries in
     Financial Economics", Journal of Finance, 75(5), 2503-2553.
 
     Args:
         * returns (DataFrame): Return series of all evaluated trials, one
             column per trial, sharing a time index.
         * target_fdr (float): Share of the discoveries that may be false.
-            Harvey and Liu use 0.05.
         * n_boot (int): Number of bootstrap draws used to build the null.
         * seed (int): Seed for the bootstrap, so the hurdle is reproducible.
         * grid_step (float): Resolution of the hurdle grid in t units.
@@ -2665,10 +2689,21 @@ def calc_fdr_hurdle(returns, target_fdr=0.05, n_boot=1000, seed=0, grid_step=0.0
     if grid_step <= 0:
         raise ValueError("grid_step must be positive")
 
-    x = pd.DataFrame(returns).dropna(axis=0, how="any")
+    x = pd.DataFrame(returns)
+    n_periods = len(x)
+    # Complete cases only: the bootstrap draws one period for every trial at once, so a
+    # period only exists for it when all of them have an observation there.
+    x = x.dropna(axis=0, how="any")
     n, m = x.shape
     if m < 2:
         raise ValueError("need at least 2 trials; the hurdle comes from the multiplicity")
+    if n < n_periods:
+        warnings.warn(
+            f"calc_fdr_hurdle kept {n} of {n_periods} periods: a period is dropped unless all {m} "
+            "trials have an observation there. Trials with staggered histories lose most of the "
+            "sample this way, and the hurdle is the one those periods imply.",
+            stacklevel=2,
+        )
     if n < 3:
         return np.nan
 
@@ -2706,7 +2741,8 @@ def calc_fdr_hurdle(returns, target_fdr=0.05, n_boot=1000, seed=0, grid_step=0.0
     null.sort()
 
     grid = np.arange(0.0, max(4.0, obs[-1] + 0.5) + grid_step, grid_step)
-    # Expected false discoveries at each hurdle, and the discoveries actually seen.
+    # Expected false discoveries at each hurdle, and the discoveries actually seen. Their
+    # ratio is E[V] / R, which is not the same quantity as E[V / R].
     expected_false = (len(null) - np.searchsorted(null, grid, side="left")) / n_boot
     discoveries = m - np.searchsorted(obs, grid, side="left")
     with np.errstate(divide="ignore", invalid="ignore"):

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2651,9 +2651,10 @@ def calc_fdr_hurdle(returns, target_fdr=0.05, n_boot=1000, seed=0, grid_step=0.0
     columns at once, which is what keeps cross-trial correlation in the null,
     and there is nothing to draw where a column is missing. Trials with
     staggered histories can lose most of the sample this way, which moves the
-    hurdle, so the number of periods kept is reported in a warning whenever any
-    row goes. Align the panel yourself if you would rather make that trade-off
-    explicitly.
+    hurdle, so the number of periods kept is reported in a warning whenever a
+    period some trials observed is dropped. A period no trial observed, such as
+    the leading row ``to_returns`` leaves, is not that trade-off and passes
+    quietly. Align the panel yourself if you would rather make it explicitly.
 
     Columns with no dispersion are dropped before the hurdle is computed. Such a
     column has no t-statistic, yet floating-point residue gives it an enormous
@@ -2690,6 +2691,10 @@ def calc_fdr_hurdle(returns, target_fdr=0.05, n_boot=1000, seed=0, grid_step=0.0
         raise ValueError("grid_step must be positive")
 
     x = pd.DataFrame(returns)
+    # A period no trial observed carries nothing for any of them and is not the
+    # complete-case trade-off the warning below is about. Drop it before counting, so
+    # the leading NaN row that to_returns() leaves does not read as a staggered history.
+    x = x.dropna(axis=0, how="all")
     n_periods = len(x)
     # Complete cases only: the bootstrap draws one period for every trial at once, so a
     # period only exists for it when all of them have an observation there.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 import ffn
 import pandas as pd
 import numpy as np
+import pytest
 from pytest import fixture
 from numpy.testing import assert_almost_equal as aae
 from packaging.version import Version
@@ -887,6 +888,107 @@ def test_calc_deflated_sharpe_ratio():
 
     # Attached to pandas objects like the other metrics
     aae(winner.calc_deflated_sharpe_ratio(sharpes), dsr)
+
+
+def _trial_t_stats(panel):
+    return (panel.mean() / (panel.std(ddof=1) / np.sqrt(len(panel)))).abs()
+
+
+def test_calc_fdr_hurdle():
+    np.random.seed(0)
+    n_periods = 500
+    index = pd.date_range(start="2015-01-01", periods=n_periods, freq="D")
+    # A search over trials that have no skill whatsoever
+    trials = pd.DataFrame(np.random.normal(0, 0.01, (n_periods, 60)), index=index)
+
+    hurdle = ffn.calc_fdr_hurdle(trials, n_boot=400, seed=0)
+    assert hurdle > 0
+    # Nothing in a skill-less search may clear the bar that search itself implies
+    assert (_trial_t_stats(trials) >= hurdle).sum() == 0
+    # ... even though its best trial looks significant on its own
+    assert _trial_t_stats(trials).max() > 2.0
+
+    # Seeded, and attached to pandas objects like the other metrics
+    assert ffn.calc_fdr_hurdle(trials, n_boot=400, seed=0) == hurdle
+    assert trials.calc_fdr_hurdle(n_boot=400, seed=0) == hurdle
+
+
+def test_calc_fdr_hurdle_rises_with_the_size_of_the_search():
+    # The bar has to come from the multiplicity, so it must climb as more
+    # candidates are tried against the same real signal. Shown on a panel that
+    # holds discoveries: where nothing clears the target the hurdle collapses to
+    # just above the best observed t and stops describing the search at all.
+    np.random.seed(11)
+    n_periods = 500
+    panel = np.random.normal(0, 0.01, (n_periods, 60))
+    for j in range(3):
+        panel[:, j] = panel[:, j] + 0.01 * 6.0 / np.sqrt(n_periods)
+    panel = pd.DataFrame(panel)
+
+    hurdles = [
+        ffn.calc_fdr_hurdle(panel.iloc[:, :k], n_boot=400, seed=0)
+        for k in (5, 20, 60)
+    ]
+    assert hurdles[0] < hurdles[1] < hurdles[2]
+    # The planted trials are strong enough to survive the widest search
+    survivors = _trial_t_stats(panel) >= hurdles[-1]
+    assert survivors[:3].all()
+
+
+def test_calc_fdr_hurdle_finds_planted_signal():
+    np.random.seed(1)
+    n_periods, n_trials = 500, 20
+    panel = pd.DataFrame(np.random.normal(0, 0.01, (n_periods, n_trials)))
+    # One trial with an edge far beyond what this search can produce by chance
+    panel[0] = panel[0] + 0.01 * 6.0 / np.sqrt(n_periods)
+
+    hurdle = ffn.calc_fdr_hurdle(panel, n_boot=400, seed=0)
+    discoveries = _trial_t_stats(panel) >= hurdle
+    assert discoveries[0]
+    assert discoveries.sum() == 1
+
+
+def test_calc_fdr_hurdle_zero_dispersion():
+    # A constant column has no t-statistic, but floating-point residue gives it an
+    # enormous finite one; left in, it would be the strongest trial in the search.
+    flat = pd.DataFrame({"a": [0.001] * 250, "b": [0.001] * 250})
+    assert np.isnan(ffn.calc_fdr_hurdle(flat, n_boot=200))
+
+    np.random.seed(2)
+    real = np.random.normal(0, 0.01, (250, 2))
+    mixed = pd.DataFrame({"flat": [0.001] * 250, "a": real[:, 0], "b": real[:, 1]})
+    assert np.isfinite(ffn.calc_fdr_hurdle(mixed, n_boot=200, seed=0))
+
+    # Dropping leaves too few trials to speak of multiplicity at all
+    with pytest.raises(ValueError):
+        ffn.calc_fdr_hurdle(
+            pd.DataFrame({"flat": [0.001] * 250, "a": real[:, 0]}), n_boot=200
+        )
+
+    # A genuinely low-volatility panel is not degenerate and must still get a number,
+    # across scales and lengths rather than at the single point the floor was set on.
+    for scale in (1e-12, 1e-6, 1.0, 1e3):
+        for n in (50, 250, 1000):
+            np.random.seed(3)
+            tiny = pd.DataFrame(np.random.normal(0, scale, (n, 5)))
+            assert np.isfinite(ffn.calc_fdr_hurdle(tiny, n_boot=200, seed=0))
+
+
+def test_calc_fdr_hurdle_guards():
+    np.random.seed(4)
+    panel = pd.DataFrame(np.random.normal(0, 0.01, (100, 5)))
+    with pytest.raises(ValueError):
+        ffn.calc_fdr_hurdle(panel, target_fdr=0.0)
+    with pytest.raises(ValueError):
+        ffn.calc_fdr_hurdle(panel, target_fdr=1.0)
+    with pytest.raises(ValueError):
+        ffn.calc_fdr_hurdle(panel, n_boot=50)
+    with pytest.raises(ValueError):
+        ffn.calc_fdr_hurdle(panel, grid_step=0)
+    with pytest.raises(ValueError):
+        ffn.calc_fdr_hurdle(panel.iloc[:, :1])
+    # Too few observations to form a t-statistic
+    assert np.isnan(ffn.calc_fdr_hurdle(panel.iloc[:2], n_boot=200))
 
 
 def test_calc_information_ratio_dataframe():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 import ffn
 import pandas as pd
 import numpy as np
+import warnings
 import pytest
 from pytest import fixture
 from numpy.testing import assert_almost_equal as aae
@@ -925,10 +926,7 @@ def test_calc_fdr_hurdle_rises_with_the_size_of_the_search():
         panel[:, j] = panel[:, j] + 0.01 * 6.0 / np.sqrt(n_periods)
     panel = pd.DataFrame(panel)
 
-    hurdles = [
-        ffn.calc_fdr_hurdle(panel.iloc[:, :k], n_boot=400, seed=0)
-        for k in (5, 20, 60)
-    ]
+    hurdles = [ffn.calc_fdr_hurdle(panel.iloc[:, :k], n_boot=400, seed=0) for k in (5, 20, 60)]
     assert hurdles[0] < hurdles[1] < hurdles[2]
     # The planted trials are strong enough to survive the widest search
     survivors = _trial_t_stats(panel) >= hurdles[-1]
@@ -961,9 +959,7 @@ def test_calc_fdr_hurdle_zero_dispersion():
 
     # Dropping leaves too few trials to speak of multiplicity at all
     with pytest.raises(ValueError):
-        ffn.calc_fdr_hurdle(
-            pd.DataFrame({"flat": [0.001] * 250, "a": real[:, 0]}), n_boot=200
-        )
+        ffn.calc_fdr_hurdle(pd.DataFrame({"flat": [0.001] * 250, "a": real[:, 0]}), n_boot=200)
 
     # A genuinely low-volatility panel is not degenerate and must still get a number,
     # across scales and lengths rather than at the single point the floor was set on.
@@ -989,6 +985,52 @@ def test_calc_fdr_hurdle_guards():
         ffn.calc_fdr_hurdle(panel.iloc[:, :1])
     # Too few observations to form a t-statistic
     assert np.isnan(ffn.calc_fdr_hurdle(panel.iloc[:2], n_boot=200))
+
+
+def test_calc_fdr_hurdle_is_two_sided():
+    # Trials are ranked on |t|, so a strongly negative strategy is a discovery too.
+    # A caller screening for outperformance has to compare the positive-t columns only.
+    np.random.seed(6)
+    n_periods = 500
+    panel = pd.DataFrame(np.random.normal(0, 0.01, (n_periods, 20)))
+    panel[0] = panel[0] - 0.01 * 6.0 / np.sqrt(n_periods)
+
+    hurdle = ffn.calc_fdr_hurdle(panel, n_boot=400, seed=0)
+    t_stats = panel.mean() / (panel.std(ddof=1) / np.sqrt(n_periods))
+    assert t_stats[0] < 0
+    assert t_stats.abs()[0] >= hurdle
+    assert (t_stats >= hurdle).sum() == 0
+
+
+def test_calc_fdr_hurdle_complete_cases_only():
+    # The bootstrap draws one period for every column at once, so a period where any
+    # trial is missing cannot be used. Trials with staggered histories lose most of the
+    # sample that way, and the hurdle moves with it, so it must not happen quietly.
+    np.random.seed(12)
+    n_periods, n_trials = 400, 20
+    panel = np.random.normal(0, 0.01, (n_periods, n_trials))
+    for j in (0, 1):  # two trials with a real edge, so both windows hold discoveries
+        panel[:, j] = panel[:, j] + 0.01 * 9.0 / np.sqrt(100)
+    full = pd.DataFrame(panel)
+    staggered = full.copy()
+    staggered.iloc[:300, n_trials - 1] = np.nan  # one trial that started late
+
+    with pytest.warns(UserWarning, match="kept 100 of 400 periods"):
+        hurdle = ffn.calc_fdr_hurdle(staggered, n_boot=200, seed=0)
+
+    # The number returned is the one those 100 shared periods imply,
+    assert hurdle == ffn.calc_fdr_hurdle(full.iloc[300:], n_boot=200, seed=0)
+    # not the one the same twenty trials give over their whole history, and the
+    # difference reaches the answer: a trial that is a discovery on the full sample
+    # is not one here.
+    hurdle_full = ffn.calc_fdr_hurdle(full, n_boot=200, seed=0)
+    assert hurdle > hurdle_full
+    assert _trial_t_stats(full.iloc[300:]).ge(hurdle).sum() < _trial_t_stats(full).ge(hurdle_full).sum()
+
+    # A complete panel says nothing, since nothing was dropped.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ffn.calc_fdr_hurdle(full, n_boot=200, seed=0)
 
 
 def test_calc_information_ratio_dataframe():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1033,6 +1033,26 @@ def test_calc_fdr_hurdle_complete_cases_only():
         ffn.calc_fdr_hurdle(full, n_boot=200, seed=0)
 
 
+def test_calc_fdr_hurdle_ignores_a_period_no_trial_observed():
+    # to_returns() leaves a leading all-NaN row, so warning on any dropped period at
+    # all fires on the ordinary construction path and trains callers to filter the
+    # warning that matters. A period nobody observed is not a staggered history.
+    np.random.seed(14)
+    prices = pd.DataFrame(
+        100 * (1 + np.random.normal(0.0004, 0.01, (250, 10))).cumprod(axis=0),
+        index=pd.date_range("2020-01-01", periods=250, freq="B"),
+    )
+    returns = prices.to_returns()
+    assert returns.iloc[0].isna().all()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        hurdle = ffn.calc_fdr_hurdle(returns, n_boot=200, seed=0)
+
+    # The row still leaves the sample, so the hurdle is the one the observed periods imply
+    assert hurdle == ffn.calc_fdr_hurdle(returns.iloc[1:], n_boot=200, seed=0)
+
+
 def test_calc_information_ratio_dataframe():
     returns = pd.DataFrame(
         {


### PR DESCRIPTION
Adds `calc_fdr_hurdle`: the t-statistic hurdle a strategy search implies at a chosen false discovery rate, as a bootstrap plug-in estimate.

It sits next to `calc_deflated_sharpe_ratio` and answers the neighbouring question. The deflated Sharpe ratio asks whether the winner survives its own selection. This asks what bar the search sets in the first place, and it needs the whole trial panel rather than a summary: one column per trial that was evaluated.

### What the number is, and what it is not

Every trial is treated as null when counting expected false discoveries, and what comes out is `E[V] / R`: expected false discoveries over the realized discovery count. That is not `E[V / R]`, and the two do not agree in general. It is a Benjamini-Hochberg / Storey-style plug-in with `m0 = m`.

It is **not** the double bootstrap of Harvey and Liu (2020), which ranks t-statistics in an outer bootstrap, assigns alternatives from a supplied share of true strategies, and averages the realized `FP / (FP + TP)` in an inner bootstrap — inputs this signature does not take. Their paper is why a hurdle of this shape is worth having; the number here is not theirs. The docstring now says that in those words, and the title and framing of this PR have been corrected to match. Thanks to @timkpaine for catching the overclaim.

### There is no universal t > 3

The bar depends on how many candidates were tried and on how correlated they were, so it is derived from the search rather than read off a table. On a panel of 60 trials with no skill whatsoever (500 daily observations, seeded):

```python
hurdle = trials.calc_fdr_hurdle()          # 2.20
trials.apply(lambda c: c.mean() / (c.std() / len(c) ** 0.5)).abs().max()   # 2.18
```

The best of those 60 trials reaches |t| = 2.18, which reads as significant on its own and is nothing of the kind: the search that produced it sets a bar of 2.20, and nothing clears it.

Plant three genuinely skilled trials in the same panel and widen the search around them:

| trials evaluated | hurdle | discoveries |
|---|---|---|
| 5 | 2.20 | 3 |
| 20 | 2.60 | 4 |
| 60 | 2.95 | 3 |

The same three strategies, the same data, a rising bar. That is the whole content of the method, and it is why the trials that were discarded belong in the panel.

### How the null is built

Each column is demeaned and the time index is resampled, drawing the **same** periods for every column so that cross-trial correlation survives into the null rather than being assumed away. The hurdle returned is the smallest one for which the target also holds at every stricter hurdle, so it cannot land on a dip in a noisy curve.

Because the alternative is never represented, the function bounds false discoveries only and says nothing about missed ones. The docstring states that rather than leaving it to be inferred.

### Missing data is complete-case, and no longer silent

A period is dropped unless every trial has an observation there. That is forced by the shared draw above — the bootstrap takes one period for all columns at once, and there is nothing to take where a column has no observation — so `GroupStats`, which keeps each series on its own calendar, cannot be followed here.

Trials with staggered histories can lose most of the sample that way, and the hurdle moves with it. So the periods kept and the periods given are now reported in a warning whenever any row goes, the docstring names the trade-off, and a test asserts the returned hurdle is the one those shared periods imply rather than the one the same trials give over their whole history.

### Two-sided, by design and now in writing

Trials are ranked on `|t|`, so a strongly negative strategy is a discovery too. A caller screening for outperformance should compare the hurdle against the positive-t columns only. Documented, and covered by a test that plants a negative trial: it clears the hurdle on `|t|` while nothing clears it on `t`.

### Zero-dispersion guard, from the start

A constant column has no t-statistic, but it does not arrive as a `nan`: the standard deviation of a constant series is floating-point residue rather than an exact zero, so a flat column divides out to something enormous but finite and would be counted as the strongest trial in the search. Such columns are dropped, and the docstring says so, since dropping changes the trial count that sets the hurdle.

This is the same failure mode this repo fixed for the deflated Sharpe ratio in #317, so the guard ships with the feature instead of arriving as a follow-up. Its test sweeps scales 1e-12 to 1e3 across lengths 50 to 1000, rather than resting on the single point the floor was calibrated on — a genuinely low-volatility panel still gets a number, only the degenerate one does not.

### Verification

- Agreement to the grid resolution with a separate implementation of the same estimator that I maintain, on both a null panel and one with planted signal (2.20 vs 2.20, 2.85 vs 2.85).
- Seeded, so the hurdle is reproducible; equality across repeated calls asserted in the tests.
- 81/81 tests pass (7 new). `ruff check` and `ruff format` introduce nothing new: verified by running both against `master` and diffing the findings, since the repo carries some pre-existing ones.
- No new dependency beyond stdlib `warnings`; numpy and pandas only otherwise.

Happy to rename the function if `calc_fdr_hurdle` still overstates it now that the estimand is spelled out — `calc_multiplicity_hurdle` would be the honest alternative.
