### PR TITLE
fix: recognise modern pandas frequency aliases in get_freq_name

### DIFF
--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -118,38 +118,59 @@ def fmtn(number: float) -> str:
 
 
 def get_freq_name(period: str) -> str | None:
-    period = period.upper()
+    # pandas anchors some aliases to a month or weekday, e.g. "YE-DEC" or "W-SUN"
+    base = period.split("-", 1)[0]
+
+    # These aliases are case sensitive in pandas: "ms" is milliseconds while
+    # "MS" is month start, so they have to be matched before upper casing
+    case_sensitive = {
+        "min": "minutely",
+        "ms": "milliseconds",
+        "us": "microseconds",
+        "ns": "nanoseconds",
+    }
+    if base in case_sensitive:
+        return case_sensitive[base]
+
     periods = {
         "B": "business day",
         "C": "custom business day",
         "D": "daily",
         "W": "weekly",
         "M": "monthly",
+        "ME": "monthly",
         "BM": "business month end",
+        "BME": "business month end",
         "CBM": "custom business month end",
+        "CBME": "custom business month end",
         "MS": "month start",
         "BMS": "business month start",
         "CBMS": "custom business month start",
         "Q": "quarterly",
+        "QE": "quarterly",
         "BQ": "business quarter end",
+        "BQE": "business quarter end",
         "QS": "quarter start",
         "BQS": "business quarter start",
         "Y": "yearly",
+        "YE": "yearly",
         "A": "yearly",
         "BA": "business year end",
+        "BY": "business year end",
+        "BYE": "business year end",
         "AS": "year start",
+        "YS": "year start",
         "BAS": "business year start",
+        "BYS": "business year start",
         "H": "hourly",
         "T": "minutely",
         "S": "secondly",
-        "L": "milliseonds",
+        "L": "milliseconds",
         "U": "microseconds",
+        "N": "nanoseconds",
     }
 
-    if period in periods:
-        return periods[period]
-    else:
-        return None
+    return periods.get(base.upper())
 
 
 def scale(val: float, src: Sequence[float], dst: Sequence[float]) -> float:

--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -118,8 +118,19 @@ def fmtn(number: float) -> str:
 
 
 def get_freq_name(period: str) -> str | None:
-    # pandas anchors some aliases to a month or weekday, e.g. "YE-DEC" or "W-SUN"
-    base = period.split("-", 1)[0]
+    match = re.fullmatch(r"(?:-?\d+)?([A-Za-z]+)(?:-([A-Za-z]+))?", period)
+    if match is None:
+        return None
+
+    base, anchor = match.groups()
+    if anchor is not None:
+        base_upper = base.upper()
+        month_anchored = {"Q", "QE", "BQ", "BQE", "QS", "BQS", "Y", "YE", "A", "BA", "BY", "BYE", "AS", "YS", "BAS", "BYS"}
+        valid_anchors = ("MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN") if base_upper == "W" else ()
+        if base_upper in month_anchored:
+            valid_anchors = ("JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC")
+        if anchor.upper() not in valid_anchors:
+            return None
 
     # These aliases are case sensitive in pandas: "ms" is milliseconds while
     # "MS" is month start, so they have to be matched before upper casing

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
-import ffn
-import ffn.utils as utils
 import pandas as pd
+
+import ffn
+from ffn import utils
 
 
 def test_memoize_handles_keyword_only_refresh():
@@ -139,6 +140,13 @@ def test_get_freq_name_anchored_aliases():
     assert utils.get_freq_name('W-SUN') == 'weekly'
 
 
+def test_get_freq_name_rejects_invalid_anchors():
+    assert utils.get_freq_name('D-NOTREAL') is None
+    assert utils.get_freq_name('ME-NOTREAL') is None
+    assert utils.get_freq_name('W-DEC') is None
+    assert utils.get_freq_name('YE-MON') is None
+
+
 def test_get_freq_name_is_case_sensitive_where_pandas_is():
     # 'ms' is milliseconds in pandas while 'MS' is month start
     assert utils.get_freq_name('ms') == 'milliseconds'
@@ -151,8 +159,13 @@ def test_get_freq_name_accepts_what_infer_freq_returns():
     # the round trip a default plot title actually takes
     for freq, expected in (
         (ffn.core._MonthEnd, 'monthly'),
+        (f'2{ffn.core._MonthEnd}', 'monthly'),
         (ffn.core._YearEnd, 'yearly'),
+        (f'2{ffn.core._YearEnd}', 'yearly'),
         ('D', 'daily'),
+        ('-1D', 'daily'),
+        ('2h', 'hourly'),
+        ('2ms', 'milliseconds'),
     ):
         idx = pd.date_range('2020-01-31', periods=8, freq=freq)
         assert utils.get_freq_name(pd.infer_freq(idx)) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import ffn
 import ffn.utils as utils
 import pandas as pd
 
@@ -111,6 +112,50 @@ def test_scale():
     assert utils.scale(-5, (0.0, 99.0), (-1.0, 1.0)) == -1.0
     assert utils.scale(105, (0.0, 99.0), (-1.0, 1.0)) == 1.0
     assert utils.scale(50, (0.0, 100.0), (-1.0, 1.0)) == 0.0
+
+
+def test_get_freq_name():
+    assert utils.get_freq_name('D') == 'daily'
+    assert utils.get_freq_name('M') == 'monthly'
+    assert utils.get_freq_name('L') == 'milliseconds'
+    assert utils.get_freq_name('zzz') is None
+
+
+def test_get_freq_name_period_end_aliases():
+    # pandas 2.2 renamed the period end aliases
+    assert utils.get_freq_name('ME') == 'monthly'
+    assert utils.get_freq_name('QE') == 'quarterly'
+    assert utils.get_freq_name('YE') == 'yearly'
+    assert utils.get_freq_name('BME') == 'business month end'
+    assert utils.get_freq_name('BQE') == 'business quarter end'
+    assert utils.get_freq_name('BYE') == 'business year end'
+
+
+def test_get_freq_name_anchored_aliases():
+    # pd.infer_freq anchors these to a month or weekday
+    assert utils.get_freq_name('YE-DEC') == 'yearly'
+    assert utils.get_freq_name('QE-DEC') == 'quarterly'
+    assert utils.get_freq_name('A-DEC') == 'yearly'
+    assert utils.get_freq_name('W-SUN') == 'weekly'
+
+
+def test_get_freq_name_is_case_sensitive_where_pandas_is():
+    # 'ms' is milliseconds in pandas while 'MS' is month start
+    assert utils.get_freq_name('ms') == 'milliseconds'
+    assert utils.get_freq_name('MS') == 'month start'
+    assert utils.get_freq_name('min') == 'minutely'
+    assert utils.get_freq_name('us') == 'microseconds'
+
+
+def test_get_freq_name_accepts_what_infer_freq_returns():
+    # the round trip a default plot title actually takes
+    for freq, expected in (
+        (ffn.core._MonthEnd, 'monthly'),
+        (ffn.core._YearEnd, 'yearly'),
+        ('D', 'daily'),
+    ):
+        idx = pd.date_range('2020-01-31', periods=8, freq=freq)
+        assert utils.get_freq_name(pd.infer_freq(idx)) == expected
 
 
 def test_as_format():


### PR DESCRIPTION
get_freq_name upper cased its input and looked it up in a table of legacy aliases, so it missed everything pandas 2.2 renamed. A monthly chart titled itself "AAPL None Price Series" because pd.infer_freq now returns "ME" and ffn's own _MonthEnd is "ME"

Anchored aliases never matched either. pd.infer_freq returns "YE-DEC" for a yearly index, and "A-DEC" on older pandas, neither of which was in the table

Upper casing also made two aliases collide. "ms" is milliseconds in pandas while "MS" is month start, so get_freq_name("ms") confidently returned "month start"

The table now carries the period end aliases, the anchor suffix is stripped before lookup, and the case sensitive aliases are matched before upper casing. Also corrects the "milliseonds" spelling