### PR TITLE
Align DataFrame risk-free returns by date

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2416,6 +2416,9 @@ def to_excess_returns(returns, rf, nperiods=None):
     """
     Given a series of returns, it will return the excess returns over rf.
 
+    A Series risk-free return is aligned to the return index. For DataFrame
+    returns, it is subtracted from every column by date.
+
     Args:
         * returns (Series, DataFrame): Returns
         * rf (float, Series): `Risk-Free rate(s) <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed in annualized term or return series
@@ -2432,6 +2435,10 @@ def to_excess_returns(returns, rf, nperiods=None):
         _rf = deannualize(rf, nperiods)
     else:
         _rf = rf
+
+    # A time-indexed risk-free Series applies to every asset column by date.
+    if isinstance(returns, pd.DataFrame) and isinstance(_rf, pd.Series):
+        return returns.sub(_rf, axis="index")
 
     return returns - _rf
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -972,17 +972,60 @@ def test_deannualize():
 
 
 def test_to_excess_returns(df):
+    """Verify scalar risk-free rates preserve existing excess-return behavior."""
     rf = 0.05
     r = df.to_returns()
 
-    np.allclose(r.to_excess_returns(0), r)
+    assert np.allclose(r.to_excess_returns(0), r, equal_nan=True)
 
-    np.allclose(
+    # A float risk-free rate is annualized only when a period count is available.
+    assert np.allclose(
         r.to_excess_returns(rf, nperiods=252),
         r.to_excess_returns(ffn.deannualize(rf, 252)),
+        equal_nan=True,
     )
 
-    np.allclose(r.to_excess_returns(rf), r - rf)
+    assert np.allclose(r.to_excess_returns(rf), r - rf, equal_nan=True)
+
+
+def test_to_excess_returns_dataframe_with_series_risk_free():
+    """Align a time-indexed risk-free Series across DataFrame rows."""
+    index = pd.date_range("2026-01-01", periods=4, freq="D")
+    returns = pd.DataFrame(
+        {
+            "fund_a": [0.03, 0.01, -0.02, 0.04],
+            "fund_b": [0.02, 0.02, -0.01, 0.03],
+        },
+        index=index,
+    )
+    risk_free = pd.Series([0.01, 0.03, 0.0, 0.04], index=index)
+    expected = pd.DataFrame(
+        {
+            "fund_a": returns["fund_a"] - risk_free,
+            "fund_b": returns["fund_b"] - risk_free,
+        },
+        index=index,
+    )
+
+    # Exercise both public paths before checking metrics built on excess returns.
+    pd.testing.assert_frame_equal(ffn.to_excess_returns(returns, risk_free), expected)
+    pd.testing.assert_frame_equal(returns.to_excess_returns(risk_free), expected)
+
+    # Each ratio is calculated independently from the expected aligned frame.
+    expected_sharpe = expected.mean() / expected.std(ddof=1)
+    pd.testing.assert_series_equal(ffn.calc_sharpe(returns, rf=risk_free, annualize=False), expected_sharpe)
+    pd.testing.assert_series_equal(returns.calc_sharpe(rf=risk_free, annualize=False), expected_sharpe)
+
+    downside_deviation = np.sqrt((expected.clip(upper=0.0) ** 2).mean())
+    expected_sortino = expected.mean() / downside_deviation
+    pd.testing.assert_series_equal(
+        ffn.calc_sortino_ratio(returns, rf=risk_free, annualize=False),
+        expected_sortino,
+    )
+    pd.testing.assert_series_equal(
+        returns.calc_sortino_ratio(rf=risk_free, annualize=False),
+        expected_sortino,
+    )
 
 
 def test_set_riskfree_rate(df):


### PR DESCRIPTION
## Summary

Align a date-indexed risk-free Series with DataFrame rows so each asset column receives the correct risk-free return.

This fixes DataFrame excess returns and the Sharpe, Sortino, and other calculations that consume them.

## Problem

### Reproducer — behavior before this fix

```python
index = pd.date_range("2026-01-01", periods=4, freq="D")

returns = pd.DataFrame(
    {
        "fund_a": [0.03, 0.01, -0.02, 0.04],
        "fund_b": [0.02, 0.02, -0.01, 0.03],
    },
    index=index,
)

risk_free = pd.Series([0.01, 0.03, 0.0, 0.04], index=index)

returns.to_excess_returns(risk_free)
```

This is valid user code that failed before the fix.

Ordinary DataFrame-minus-Series subtraction aligns the Series with DataFrame columns. The four dates were therefore treated as additional columns, producing a `(4, 6)` all-NaN DataFrame instead of the expected `(4, 2)` result.

Sharpe and Sortino calculations inherited the invalid excess returns and also returned NaNs.

## Change

For DataFrame returns with a Series risk-free return, subtract explicitly along the date index:

```python
returns.sub(risk_free, axis="index")
```

The new branch applies only to this input combination. Existing behavior remains unchanged for:

- Series returns with a Series risk-free return
- DataFrame returns with DataFrame risk-free returns
- Scalar risk-free rates
- Risk-free deannualization and ratio annualization

The function docstring now documents the alignment behavior. Existing scalar-rate test comparisons were also converted into effective assertions.

## Numerical reference

The expected excess returns are calculated independently by subtracting the risk-free Series from each asset column.

With `annualize=False`, the expected ratios are:

- Sharpe: `fund_a=-0.2611164839`, `fund_b=-0.5`
- Sortino: `fund_a=-0.3535533906`, `fund_b=-0.5773502692`

Sharpe retains its existing sample standard deviation (`ddof=1`), and Sortino retains its existing downside-deviation calculation.

## Regression coverage

The deterministic regression checks:

- Module-level `ffn.to_excess_returns`
- Pandas-method `DataFrame.to_excess_returns`
- Module-level and pandas-method Sharpe ratios
- Module-level and pandas-method Sortino ratios
- Existing scalar risk-free behavior

## Verification

Tested on macOS arm64 with Python 3.10.21, pandas 2.3.3, and NumPy 2.2.6.

- Focused excess-return, Sharpe, and Sortino tests: `10 passed`
- Complete core test module: `66 passed`
- Native `make lint`: passed
- Native full repository suite: `75 passed`
- Branch coverage: 63%
- Changed source and test sections passed Ruff lint and formatting checks
- `git diff --check`: passed

The complete test module retains its existing whole-file Ruff findings and formatting debt; this PR does not add to them.

## Scope exclusions

This PR does not change:

- `PerformanceStats`’ separate risk-free price-series convention
- Frequency inference
- Missing-date filling policy
- Annualization conventions
- Public signatures or exports
- Dependencies, packaging, or configuration