### PR TITLE
Fix price index baseline for mixed leading NaNs

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1183,28 +1183,30 @@ def to_price_index(returns, start=100):
     Assumes arithmetic returns.
 
     The first value of the returned price index is always ``start``.
-    When the return series begins with NaN (as produced by
-    :func:`to_returns`), the NaN position is replaced by ``start`` and
-    the output length equals the input length.  Otherwise ``start`` is
-    prepended so that every return is reflected in the prices and the
-    round-trip ``to_returns(to_price_index(r))`` recovers *r*.
+    When a Series begins with NaN, or every column of a DataFrame begins
+    with NaN (as produced by :func:`to_returns`), the NaN position is
+    replaced by ``start`` and the output length equals the input length.
+    Otherwise ``start`` is prepended so that every non-missing return is
+    reflected in the prices.  Missing returns are treated as zero, and
+    the round-trip ``to_returns(to_price_index(r))`` recovers the
+    non-missing returns.
 
     Formula is: start, start * cumprod(1+r)
     """
     r = returns.replace(to_replace=np.nan, value=0)
     cp = (1 + r).cumprod() * start
 
-    # If the first return was NaN (e.g. from to_returns()), the replace
-    # already turned it into 0 so cp starts at ``start``.  Just return.
+    # If all initial returns are missing (e.g. from to_returns()), the
+    # replacement turns them into 0 so cp starts at ``start``. Just return.
     if isinstance(returns, pd.DataFrame):
-        has_leading_nan = returns.iloc[0].isna().any()
+        has_leading_nan = returns.iloc[0].isna().all()
     else:
         has_leading_nan = np.isnan(returns.iloc[0])
 
     if has_leading_nan:
         return cp
 
-    # No leading NaN – prepend ``start`` so the first price equals start.
+    # Prepend ``start`` so every output series starts at the same baseline.
     start_index = cp.index[0]
     if isinstance(cp.index, pd.DatetimeIndex):
         frequency = cp.index.freq

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1201,7 +1201,7 @@ def to_price_index(returns, start=100):
     if isinstance(returns, pd.DataFrame):
         has_leading_nan = returns.iloc[0].isna().all()
     else:
-        has_leading_nan = np.isnan(returns.iloc[0])
+        has_leading_nan = pd.isna(returns.iloc[0])
 
     if has_leading_nan:
         return cp
@@ -1218,9 +1218,11 @@ def to_price_index(returns, start=100):
             start_index -= cp.index[1] - cp.index[0]
         else:
             start_index -= pd.Timedelta(days=1)
+    elif isinstance(cp.index, pd.RangeIndex):
+        start_index -= cp.index.step
 
     if isinstance(cp, pd.DataFrame):
-        start_row = pd.DataFrame({c: [start] for c in cp.columns}, index=[start_index])
+        start_row = pd.DataFrame(start, columns=cp.columns, index=[start_index])
     else:
         start_row = pd.Series([start], index=[start_index], name=cp.name)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -142,6 +142,29 @@ def test_to_price_index(df):
     aae(actual["C"].iloc[9], 1.012, 3)
 
 
+def test_to_price_index_mixed_leading_nan_dataframe():
+    returns = pd.DataFrame(
+        {
+            "missing_first": [np.nan, 0.10, -0.05],
+            "valid_first": [0.20, -0.10, 0.05],
+        },
+        index=pd.date_range("2024-01-08", periods=3, freq="B"),
+    )
+
+    start = 250
+    prices = returns.to_price_index(start=start)
+
+    assert len(prices) == len(returns) + 1
+    assert prices.index.is_unique
+    assert prices.index[0] == returns.index[0] - pd.offsets.BusinessDay()
+    assert np.allclose(prices.iloc[0].to_numpy(), start)
+
+    roundtrip = prices.to_returns()
+    assert np.allclose(roundtrip["valid_first"].iloc[1:].to_numpy(), returns["valid_first"].to_numpy())
+    assert np.isclose(roundtrip["missing_first"].iloc[1], 0)
+    assert np.allclose(roundtrip["missing_first"].iloc[2:].to_numpy(), returns["missing_first"].iloc[1:].to_numpy())
+
+
 def test_to_price_index_preserves_first_return_in_stats():
     returns = pd.Series(
         [0.10, -0.05, 0.02, 0.03],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -165,6 +165,37 @@ def test_to_price_index_mixed_leading_nan_dataframe():
     assert np.allclose(roundtrip["missing_first"].iloc[2:].to_numpy(), returns["missing_first"].iloc[1:].to_numpy())
 
 
+def test_to_price_index_mixed_leading_nan_range_index():
+    returns = pd.DataFrame({"missing_first": [np.nan, 0.10], "valid_first": [0.20, -0.10]})
+
+    prices = returns.to_price_index()
+
+    assert prices.index.equals(pd.Index([-1, 0, 1]))
+    assert np.allclose(prices.to_returns().iloc[1:].to_numpy(), returns.fillna(0).to_numpy())
+
+
+def test_to_price_index_preserves_duplicate_columns():
+    returns = pd.DataFrame(
+        [[np.nan, 0.20], [0.10, -0.10]],
+        columns=["duplicate", "duplicate"],
+        index=pd.date_range("2024-01-01", periods=2),
+    )
+
+    prices = returns.to_price_index()
+
+    assert prices.columns.equals(returns.columns)
+    assert np.allclose(prices.to_returns().iloc[1:].to_numpy(), returns.fillna(0).to_numpy())
+
+
+def test_to_price_index_nullable_series():
+    returns = pd.Series([pd.NA, 0.10], dtype="Float64")
+
+    prices = returns.to_price_index()
+
+    assert prices.index.equals(returns.index)
+    assert np.allclose(prices.to_numpy(dtype=float), [100, 110])
+
+
 def test_to_price_index_preserves_first_return_in_stats():
     returns = pd.Series(
         [0.10, -0.05, 0.02, 0.03],


### PR DESCRIPTION
A DataFrame with both missing and valid first-row returns currently omits the starting-price row. Converting the resulting prices back to returns then loses the valid first return.

Reuse the first row as the baseline only when every column starts with NaN. Add a regression test for the common starting value, unique dates, and return round-trip.

Validation: `python -m pytest tests -q` — 75 passed (Python 3.12, pandas 2.3.3). Ruff formatting passed; Ruff 0.15.12 reports the same two existing E712 findings on the base commit. Coverage and other dependency combinations were not run.