### PR TITLE
Fix drawdown_details for series starting in a drawdown

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1377,6 +1377,10 @@ def drawdown_details(drawdown, index_type=pd.DatetimeIndex):
     end = is_zero & (~is_zero).shift(1)
     end = list(end[end == True].index)
 
+    # A sliced series may already be underwater at its first observation.
+    if len(drawdown) > 0 and drawdown.iloc[0] < 0:
+        start.insert(0, drawdown.index[0])
+
     if len(start) == 0:  # start.empty
         return None
 

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1378,7 +1378,7 @@ def drawdown_details(drawdown, index_type=pd.DatetimeIndex):
     end = list(end[end == True].index)
 
     # A sliced series may already be underwater at its first observation.
-    if len(drawdown) > 0 and drawdown.iloc[0] < 0:
+    if len(drawdown) > 0 and pd.notna(drawdown.iloc[0]) and drawdown.iloc[0] < 0:
         start.insert(0, drawdown.index[0])
 
     if len(start) == 0:  # start.empty
@@ -1402,7 +1402,7 @@ def drawdown_details(drawdown, index_type=pd.DatetimeIndex):
     result = pd.DataFrame(columns=("Start", "End", "Length", "drawdown"), index=range(len(start)))
 
     for i in range(len(start)):
-        dd = drawdown[start[i] : end[i]].min()
+        dd = drawdown.loc[start[i] : end[i]].min()
 
         if index_type is pd.DatetimeIndex:
             result.iloc[i] = (start[i], end[i], (end[i] - start[i]).days, dd)

--- a/tests/test_drawdown_details.py
+++ b/tests/test_drawdown_details.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import ffn
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ([-0.1, -0.2, -0.05], [(0, 2, -0.2)]),
+        ([-0.1, -0.2, 0.0], [(0, 2, -0.2)]),
+        ([-0.1], [(0, 0, -0.1)]),
+        ([-0.1, 0.0, -0.2, 0.0], [(0, 1, -0.1), (2, 3, -0.2)]),
+        ([0.0, -0.1, 0.0], [(1, 2, -0.1)]),
+    ],
+)
+def test_drawdown_details_includes_initial_drawdown(values, expected):
+    index = pd.date_range("2024-01-01", periods=len(values))
+    drawdown = pd.Series(values, index=index)
+    original = drawdown.copy()
+
+    result = ffn.drawdown_details(drawdown)
+
+    assert result is not None
+    assert len(result) == len(expected)
+    for row, (start, end, minimum) in zip(result.itertuples(index=False), expected):
+        assert row.Start == index[start]
+        assert row.End == index[end]
+        assert row.Length == end - start
+        assert row.drawdown == minimum
+    pd.testing.assert_series_equal(drawdown, original)
+
+
+@pytest.mark.parametrize("values", [[], [0.0], [0.0, 0.0], [np.nan, 0.0]])
+def test_drawdown_details_without_drawdowns(values):
+    drawdown = pd.Series(values, index=pd.date_range("2024-01-01", periods=len(values)), dtype=float)
+    assert ffn.drawdown_details(drawdown) is None

--- a/tests/test_drawdown_details.py
+++ b/tests/test_drawdown_details.py
@@ -36,3 +36,25 @@ def test_drawdown_details_includes_initial_drawdown(values, expected):
 def test_drawdown_details_without_drawdowns(values):
     drawdown = pd.Series(values, index=pd.date_range("2024-01-01", periods=len(values)), dtype=float)
     assert ffn.drawdown_details(drawdown) is None
+
+
+def test_drawdown_details_with_nullable_missing_initial_value():
+    drawdown = pd.Series([pd.NA, 0.0], dtype="Float64")
+    assert ffn.drawdown_details(drawdown, index_type=drawdown.index) is None
+
+
+@pytest.mark.parametrize(
+    "values, expected_minimum",
+    [
+        ([-0.1], -0.1),
+        ([-0.1, -0.2], -0.2),
+    ],
+)
+def test_drawdown_details_with_initial_drawdown_and_range_index(values, expected_minimum):
+    drawdown = pd.Series(values)
+
+    result = ffn.drawdown_details(drawdown, index_type=drawdown.index)
+
+    assert result is not None
+    assert len(result) == 1
+    assert result.iloc[0].drawdown == expected_minimum


### PR DESCRIPTION
## Summary

Include a drawdown already in progress at the first observation of a supplied Series. `drawdown_details` currently returns `None` if that is the only drawdown, because it checks for an empty list of zero-to-negative transitions before accounting for a series that begins underwater.

For example, `ffn.drawdown_details(pd.Series([-0.1, -0.2, 0.0], index=pd.date_range("2024-01-01", periods=3)))` should describe one recovered drawdown, but returns `None` on upstream.

Record the first observation as the start before the early return. This follows the function's existing convention for truncated drawdowns and leaves the input unchanged.

## Verification

- Added nine cases covering ongoing/recovered/single-observation initial drawdowns, subsequent drawdowns, a normal zero-start series, empty/all-zero data, and a missing initial value.
- Before the fix, three initial-drawdown cases failed because the result was `None`.
- `python -m pytest tests -q --tb=short`: **83 passed**.
- `python -m ruff check ffn/core.py tests/test_drawdown_details.py`: passed.
- `python -m ruff format --check ffn/core.py tests/test_drawdown_details.py`: passed.
- `git diff --check`: passed.

Tested with Python 3.12, pandas 2.3.3, and NumPy 1.26.4. No external data downloads were used.
