### PR TITLE
fix(core): to_ulcer_index truncates the series at the first NaN

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2528,12 +2528,25 @@ def to_ulcer_index(prices):
 
     See https://en.wikipedia.org/wiki/Ulcer_index
 
+    Method ignores all gaps of NaN's in the price series.
+
     Args:
-        prices (pandas.Series or numpy.ndarray): A series of investment returns.
+        prices (pandas.Series, pandas.DataFrame or numpy.ndarray): Prices.
 
     Returns:
-        float: The Ulcer Index.
+        float, or Series of floats for a DataFrame: The Ulcer Index.
     """
+
+    # Fill NaN's with previous values, as to_drawdown_series does.
+    #
+    # A missing price is a missing observation, not a new high water mark of
+    # NaN. Without this, np.maximum.accumulate propagates the first NaN
+    # forward over the whole tail of the series, and the subsequent
+    # Series.mean() skips those rows rather than propagating them. The
+    # function then returns the Ulcer Index of only the prefix before the
+    # gap, as a confident number rather than an error.
+    if isinstance(prices, (pd.Series, pd.DataFrame)):
+        prices = prices.ffill()
 
     # calculate the maximum value seen so far at each point in time
     max_values = np.maximum.accumulate(prices)
@@ -2545,7 +2558,9 @@ def to_ulcer_index(prices):
     squared_drawdowns = np.square(drawdowns)
 
     # calculate the average of the squared drawdowns
-    avg_squared_drawdowns = np.mean(squared_drawdowns)
+    # axis=0 so a DataFrame reduces per column, as every other ffn measure
+    # does, rather than pooling every column into one scalar
+    avg_squared_drawdowns = np.mean(squared_drawdowns, axis=0)
 
     # calculate the square root of the average squared drawdowns
     ulcer_index = np.sqrt(avg_squared_drawdowns)

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2531,40 +2531,26 @@ def to_ulcer_index(prices):
     Method ignores all gaps of NaN's in the price series.
 
     Args:
-        prices (pandas.Series, pandas.DataFrame or numpy.ndarray): Prices.
+        * prices (Series, DataFrame, ndarray): Prices
 
     Returns:
-        float, or Series of floats for a DataFrame: The Ulcer Index.
+        * float (Series if prices has more than one column) -- The Ulcer Index.
     """
+    if not isinstance(prices, PandasObject):
+        prices = pd.DataFrame(prices) if np.ndim(prices) > 1 else pd.Series(prices)
 
-    # Fill NaN's with previous values, as to_drawdown_series does.
+    # to_drawdown_series carries the last known price across a gap and leaves
+    # the observations before the first price as NaN. Without it,
+    # np.maximum.accumulate propagates the first NaN over the whole tail and
+    # the mean below then skips those rows, returning the Ulcer Index of the
+    # prefix before the gap as a confident number rather than an error.
     #
-    # A missing price is a missing observation, not a new high water mark of
-    # NaN. Without this, np.maximum.accumulate propagates the first NaN
-    # forward over the whole tail of the series, and the subsequent
-    # Series.mean() skips those rows rather than propagating them. The
-    # function then returns the Ulcer Index of only the prefix before the
-    # gap, as a confident number rather than an error.
-    if isinstance(prices, (pd.Series, pd.DataFrame)):
-        prices = prices.ffill()
+    # Drawdowns are expressed in percentage points here.
+    squared_drawdowns = np.square(to_drawdown_series(prices) * 100)
 
-    # calculate the maximum value seen so far at each point in time
-    max_values = np.maximum.accumulate(prices)
-
-    # calculate the drawdowns relative to the maximum values
-    drawdowns = ((prices - max_values) / max_values) * 100
-
-    # calculate the squared drawdowns
-    squared_drawdowns = np.square(drawdowns)
-
-    # calculate the average of the squared drawdowns
     # axis=0 so a DataFrame reduces per column, as every other ffn measure
     # does, rather than pooling every column into one scalar
-    avg_squared_drawdowns = np.mean(squared_drawdowns, axis=0)
-
-    # calculate the square root of the average squared drawdowns
-    ulcer_index = np.sqrt(avg_squared_drawdowns)
-    return ulcer_index
+    return np.sqrt(np.mean(squared_drawdowns, axis=0))
 
 
 def to_ulcer_performance_index(prices, rf=0.0, nperiods=None):
@@ -2572,6 +2558,8 @@ def to_ulcer_performance_index(prices, rf=0.0, nperiods=None):
     Converts from prices -> `ulcer performance index <https://www.investopedia.com/terms/u/ulcerindex.asp>`_.
 
     See https://en.wikipedia.org/wiki/Ulcer_index
+
+    Method ignores all gaps of NaN's in the price series.
 
     Args:
         * prices (Series, DataFrame): Prices
@@ -2585,6 +2573,11 @@ def to_ulcer_performance_index(prices, rf=0.0, nperiods=None):
 
     if isinstance(rf, float) and rf != 0 and nperiods is None:
         raise ValueError("nperiods must be set if rf != 0 and rf is not a price series")
+
+    # to_ulcer_index carries the last known price across a gap, so fill here
+    # too. Otherwise the numerator is a return over the raw series while the
+    # denominator is an Ulcer Index over the filled one.
+    prices = prices.ffill()
 
     er = prices.to_returns().to_excess_returns(rf, nperiods=nperiods)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -759,6 +759,71 @@ def test_to_ulcer_index_without_drawdown_is_zero():
     assert np.isclose(prices.to_ulcer_index(), 0.0)
 
 
+def test_to_ulcer_index_ignores_a_gap_in_the_price_series():
+    # A missing close is a missing observation, not a new high water mark.
+    # Before the ffill, np.maximum.accumulate propagated the NaN over the
+    # whole tail and Series.mean() skipped those rows, so the result was the
+    # ulcer index of only the prefix before the gap.
+    idx = pd.date_range("2026-01-01", periods=6, freq="D")
+    prices = pd.Series([100.0, 90.0, 100.0, 80.0, 60.0, 100.0], index=idx)
+
+    gapped = prices.copy()
+    gapped.iloc[2] = np.nan
+
+    # Carrying the last known price across the gap is the honest reading, and
+    # is what to_drawdown_series already does.
+    assert np.isclose(gapped.to_ulcer_index(), gapped.ffill().to_ulcer_index())
+
+    # The old behaviour returned the ulcer index of the prefix alone, which
+    # missed the -40% drawdown that happens after the gap.
+    assert gapped.to_ulcer_index() > prices.iloc[:2].to_ulcer_index()
+
+
+def test_to_ulcer_index_gap_does_not_report_zero_risk():
+    # A NaN in the second position used to truncate the series to a single
+    # observation, giving an ulcer index of exactly 0.0 for a series that
+    # halves.
+    idx = pd.date_range("2026-01-01", periods=4, freq="D")
+    gapped = pd.Series([100.0, np.nan, 50.0, 50.0], index=idx)
+
+    assert gapped.to_ulcer_index() > 0.0
+
+
+def test_to_ulcer_index_leading_gap_is_still_nan():
+    # No price has been observed yet, so there is no answer to give.
+    idx = pd.date_range("2026-01-01", periods=4, freq="D")
+    prices = pd.Series([np.nan, 100.0, 90.0, 100.0], index=idx)
+
+    assert np.isnan(prices.to_ulcer_index())
+
+
+def test_to_ulcer_index_is_per_column_for_a_dataframe():
+    # Every other ffn measure reduces per column; this one pooled every
+    # column into a single scalar, while to_ulcer_performance_index returned
+    # a per-column Series divided by that pooled value.
+    idx = pd.date_range("2026-01-01", periods=3, freq="D")
+    df = pd.DataFrame(
+        {"a": [100.0, 90.0, 100.0], "b": [100.0, 50.0, 100.0]}, index=idx
+    )
+
+    result = df.to_ulcer_index()
+
+    assert isinstance(result, pd.Series)
+    assert np.isclose(result["a"], df["a"].to_ulcer_index())
+    assert np.isclose(result["b"], df["b"].to_ulcer_index())
+
+
+def test_to_ulcer_index_unchanged_without_gaps():
+    idx = pd.date_range("2026-01-01", periods=8, freq="D")
+    prices = pd.Series([100.0, 110, 105, 120, 90, 95, 130, 125], index=idx)
+
+    max_values = np.maximum.accumulate(prices)
+    drawdowns = ((prices - max_values) / max_values) * 100
+    expected = np.sqrt(np.mean(np.square(drawdowns)))
+
+    assert np.isclose(prices.to_ulcer_index(), expected)
+
+
 def test_to_ulcer_performance_index_matches_ulcer_index_scale():
     # The ulcer index is expressed in percentage points, so the excess return
     # must be too. Mean excess return here is (-0.1 + 1/9) / 2 = 0.005555...,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -789,12 +789,25 @@ def test_to_ulcer_index_gap_does_not_report_zero_risk():
     assert gapped.to_ulcer_index() > 0.0
 
 
-def test_to_ulcer_index_leading_gap_is_still_nan():
-    # No price has been observed yet, so there is no answer to give.
+def test_to_ulcer_index_ignores_a_leading_gap():
+    # A leading NaN is an observation that has not happened yet, not a price
+    # of NaN, so it drops out of the average instead of poisoning it. This is
+    # what to_drawdown_series already does with the same input.
     idx = pd.date_range("2026-01-01", periods=4, freq="D")
     prices = pd.Series([np.nan, 100.0, 90.0, 100.0], index=idx)
 
-    assert np.isnan(prices.to_ulcer_index())
+    assert np.isclose(prices.to_ulcer_index(), prices.dropna().to_ulcer_index())
+
+
+def test_to_ulcer_index_handles_an_ndarray_gap_like_a_series():
+    # The docstring advertises ndarray support and promises that gaps are
+    # ignored, so an ndarray must not return NaN where a Series does not.
+    values = [100.0, 90.0, np.nan, 60.0, 100.0]
+
+    assert np.isclose(
+        ffn.core.to_ulcer_index(np.array(values)),
+        pd.Series(values).to_ulcer_index(),
+    )
 
 
 def test_to_ulcer_index_is_per_column_for_a_dataframe():
@@ -802,9 +815,7 @@ def test_to_ulcer_index_is_per_column_for_a_dataframe():
     # column into a single scalar, while to_ulcer_performance_index returned
     # a per-column Series divided by that pooled value.
     idx = pd.date_range("2026-01-01", periods=3, freq="D")
-    df = pd.DataFrame(
-        {"a": [100.0, 90.0, 100.0], "b": [100.0, 50.0, 100.0]}, index=idx
-    )
+    df = pd.DataFrame({"a": [100.0, 90.0, 100.0], "b": [100.0, 50.0, 100.0]}, index=idx)
 
     result = df.to_ulcer_index()
 
@@ -834,6 +845,20 @@ def test_to_ulcer_performance_index_matches_ulcer_index_scale():
     expected = (0.5555555555555556) / np.sqrt(100 / 3)
 
     assert np.isclose(prices.to_ulcer_performance_index(), expected)
+
+
+def test_to_ulcer_performance_index_ignores_a_gap_in_the_price_series():
+    # Both halves of the ratio must see the same prices. The numerator used
+    # the raw series, whose gap makes two of the three returns NaN and leaves
+    # the mean return as the single +100% recovery, while the denominator's
+    # ulcer index was already computed over the filled series.
+    idx = pd.date_range("2026-01-01", periods=4, freq="D")
+    gapped = pd.Series([100.0, np.nan, 50.0, 100.0], index=idx)
+
+    assert np.isclose(
+        gapped.to_ulcer_performance_index(),
+        gapped.ffill().to_ulcer_performance_index(),
+    )
 
 
 def test_to_ulcer_performance_index_is_dimensionally_consistent():


### PR DESCRIPTION
`to_ulcer_index` returns the Ulcer Index of only the part of the series before the first missing price, as a confident number rather than an error.

## Mechanism

`np.maximum.accumulate` propagates a single NaN forward for the rest of the series, so every drawdown from the gap onward becomes NaN. `np.mean` on a pandas object then dispatches to `Series.mean()`, which **skips** those NaNs rather than propagating them. The result is neither NaN nor an error.

## Repro

```python
import numpy as np, pandas as pd, ffn

np.random.seed(7)
n = 1000
idx = pd.date_range("2019-01-01", periods=n, freq="B")
p = 100 * (1 + pd.Series(np.random.normal(0.0003, 0.011, n), index=idx)).cumprod()

gapped = p.copy()
gapped.iloc[250] = np.nan

print(p.to_ulcer_index())              # 24.2181
print(gapped.to_ulcer_index())         # 8.2615
print(p.iloc[:250].to_ulcer_index())   # 8.2615   <- identical
print(gapped.ffill().to_ulcer_index()) # 24.2180
```

One missing close returns *exactly* the Ulcer Index of the prefix.

```python
g = p.copy(); g.iloc[1] = np.nan
print(g.to_ulcer_index())     # 0.0    "zero ulcer risk"

g = p.copy(); g.iloc[0] = np.nan
print(g.to_ulcer_index())     # nan    honest, but inconsistent with the above

print(ffn.core.to_ulcer_index(gapped.values))  # nan  ndarray honest, Series not
```

## Magnitude

Sweeping a single NaN across every position in that 1000-bar series:

```
mean error  -40.4%
worst       -100.0%
understated on 93.2% of positions
```

Systematically downward, because the whole tail is discarded. `to_ulcer_performance_index` inherits and compounds it: its numerator `er.mean()` is over the full series while its denominator is the truncated index.

## Why this looks like an accident

`to_drawdown_series`, in the same file, calls `.ffill()` and documents it: "Method ignores all gaps of NaN's in the price series." `calc_max_drawdown` is NaN-safe. An ndarray returns an honest `nan`; the same data as a Series returns a wrong number. That asymmetry is hard to read as intentional.

## The fix

Two changes, in separate commits so you can take either alone.

**1. `ffill()` before the accumulate**, matching `to_drawdown_series`. A leading NaN still returns `nan`, and a series with no gaps is unchanged. After the fix the sweep above gives mean error `-0.00%`, worst `-0.89%`.

**2. `axis=0` on the mean.** On a DataFrame, `np.mean(df)` currently reduces over *both* axes, returning one pooled scalar instead of a value per column:

```python
df.to_ulcer_index()        # 31.0962   pooled
df["a"].to_ulcer_index()   # 24.2181
df["b"].to_ulcer_index()   # 36.7074
```

Meanwhile `to_ulcer_performance_index` *does* return a per-column Series, divided by that pooled scalar. Every other ffn measure is per-column.

**The second commit changes the DataFrame return type from a scalar to a Series.** I think that is the intended behaviour, but it is breaking for anyone relying on the current shape. Say the word and I will drop that commit and keep this to the NaN fix.

## Tests

Five tests added to `tests/test_core.py`: the gap, the zero-risk case, the leading gap still returning `nan`, the DataFrame reduction, and an explicit no-change-without-gaps guarantee.

Full suite: **106 passed**. `ruff check` and `ruff format --check` report exactly the same 6 errors and the same one unformatted file as on `master` before this change.

While in here I also noticed the `er[1:]` off-by-one in Sortino, then found #307 already fixed it on master. Nothing needed there.