### PR TITLE
Align returns and benchmark on the index, not on columns

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1510,9 +1510,21 @@ def calc_prob_mom(returns, other_returns):
     # much evidence there is rather than just the per-period edge. n counts
     # the aligned, non-NaN differentials actually used in the information
     # ratio, not the raw series length.
-    n = (returns - other_returns).count()
+    if isinstance(returns, pd.DataFrame) and isinstance(other_returns, pd.Series):
+        diff_rets = returns.sub(other_returns, axis="index")
+    else:
+        diff_rets = returns - other_returns
+
+    n = diff_rets.count()
     ir = returns.calc_information_ratio(other_returns)
-    return t.cdf(ir * np.sqrt(n), n - 1)
+    t_stat = ir * np.sqrt(n)
+    prob = t.cdf(t_stat, n - 1)
+
+    # t.cdf drops the labels, so put them back for column-wise input
+    if isinstance(t_stat, pd.Series):
+        return pd.Series(prob, index=t_stat.index)
+
+    return prob
 
 
 def calc_total_return(prices):

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1473,14 +1473,29 @@ def calc_sharpe(returns, rf=0.0, nperiods=None, annualize=True):
     return res
 
 
+def _diff_returns(returns, benchmark_returns):
+    """
+    Subtracts benchmark_returns from returns along the date index.
+
+    A bare ``-`` between a DataFrame and a Series aligns the Series against
+    the frame's *columns*, so a date-indexed benchmark silently produces an
+    all-NaN frame the size of the calendar plus the column labels. Subtract
+    along the index whenever the two arguments have different shapes.
+    """
+    if isinstance(returns, pd.DataFrame) and isinstance(benchmark_returns, pd.Series):
+        return returns.sub(benchmark_returns, axis="index")
+
+    if isinstance(returns, pd.Series) and isinstance(benchmark_returns, pd.DataFrame):
+        return benchmark_returns.rsub(returns, axis="index")
+
+    return returns - benchmark_returns
+
+
 def calc_information_ratio(returns, benchmark_returns):
     """
     Calculates the `Information ratio <https://www.investopedia.com/terms/i/informationratio.asp>`_ (or `from Wikipedia <http://en.wikipedia.org/wiki/Information_ratio>`_).
     """
-    if isinstance(returns, pd.DataFrame) and isinstance(benchmark_returns, pd.Series):
-        diff_rets = returns.sub(benchmark_returns, axis="index")
-    else:
-        diff_rets = returns - benchmark_returns
+    diff_rets = _diff_returns(returns, benchmark_returns)
     diff_std = diff_rets.std(ddof=1)
 
     if isinstance(diff_std, pd.Series):
@@ -1510,12 +1525,7 @@ def calc_prob_mom(returns, other_returns):
     # much evidence there is rather than just the per-period edge. n counts
     # the aligned, non-NaN differentials actually used in the information
     # ratio, not the raw series length.
-    if isinstance(returns, pd.DataFrame) and isinstance(other_returns, pd.Series):
-        diff_rets = returns.sub(other_returns, axis="index")
-    else:
-        diff_rets = returns - other_returns
-
-    n = diff_rets.count()
+    n = _diff_returns(returns, other_returns).count()
     ir = returns.calc_information_ratio(other_returns)
     t_stat = ir * np.sqrt(n)
     prob = t.cdf(t_stat, n - 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -840,6 +840,37 @@ def test_calc_prob_mom_ignores_unaligned_observations():
     assert np.isclose(padded.calc_prob_mom(short_benchmark), expected)
 
 
+def test_calc_prob_mom_dataframe_against_series_benchmark():
+    """Test that a Series benchmark aligns on the index, not on the columns"""
+    returns, benchmark = _diff_series(250)
+    frame = pd.DataFrame({"a": returns, "b": returns * 2})
+
+    result = frame.calc_prob_mom(benchmark)
+
+    assert isinstance(result, pd.Series)
+    assert list(result.index) == ["a", "b"]
+    # Each column must match the value its own Series carries
+    for col in frame:
+        assert np.isclose(result[col], frame[col].calc_prob_mom(benchmark))
+
+
+def test_calc_prob_mom_dataframe_ignores_unaligned_observations():
+    """Test that the per-column sample size still excludes NaN and non-overlapping dates"""
+    returns, benchmark = _diff_series(250)
+    padded = returns.copy()
+    padded.iloc[0] = np.nan  # e.g. the leading NaN from to_returns()
+    frame = pd.DataFrame({"a": returns, "b": padded})
+    short_benchmark = benchmark.iloc[:100]
+
+    result = frame.calc_prob_mom(short_benchmark)
+
+    # Column "b" only overlaps on 99 dates, column "a" on 100
+    assert np.isclose(result["a"], returns.iloc[:100].calc_prob_mom(short_benchmark))
+    assert np.isclose(
+        result["b"], returns.iloc[1:100].calc_prob_mom(benchmark.iloc[1:100])
+    )
+
+
 def test_calmar_ratio(df):
     cagr = df.calc_cagr()
     mdd = df.calc_max_drawdown()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -866,9 +866,35 @@ def test_calc_prob_mom_dataframe_ignores_unaligned_observations():
 
     # Column "b" only overlaps on 99 dates, column "a" on 100
     assert np.isclose(result["a"], returns.iloc[:100].calc_prob_mom(short_benchmark))
-    assert np.isclose(
-        result["b"], returns.iloc[1:100].calc_prob_mom(benchmark.iloc[1:100])
-    )
+    assert np.isclose(result["b"], returns.iloc[1:100].calc_prob_mom(benchmark.iloc[1:100]))
+
+
+def test_calc_prob_mom_series_against_dataframe_benchmark():
+    """Test that a DataFrame benchmark aligns on the index, not on the columns"""
+    returns, benchmark = _diff_series(250)
+    frame = pd.DataFrame({"a": benchmark, "b": benchmark + 0.0005})
+
+    result = returns.calc_prob_mom(frame)
+
+    assert isinstance(result, pd.Series)
+    assert list(result.index) == ["a", "b"]
+    # Each benchmark column must match the value it carries on its own
+    for col in frame:
+        assert np.isclose(result[col], returns.calc_prob_mom(frame[col]))
+
+
+def test_calc_prob_mom_dataframe_against_dataframe_benchmark():
+    """Test that a column-wise result stays labelled by the frame's columns"""
+    returns, benchmark = _diff_series(250)
+    frame = pd.DataFrame({"a": returns, "b": returns * 2})
+    benchmarks = pd.DataFrame({"a": benchmark, "b": benchmark + 0.0005})
+
+    result = frame.calc_prob_mom(benchmarks)
+
+    assert isinstance(result, pd.Series)
+    assert list(result.index) == ["a", "b"]
+    for col in frame:
+        assert np.isclose(result[col], frame[col].calc_prob_mom(benchmarks[col]))
 
 
 def test_calmar_ratio(df):
@@ -1009,6 +1035,24 @@ def test_calc_information_ratio_dataframe_with_series_benchmark():
 
     actual = returns.calc_information_ratio(benchmark)
     difference = returns.sub(benchmark, axis="index")
+    expected = difference.mean() / difference.std(ddof=1)
+
+    pd.testing.assert_series_equal(actual, expected)
+
+
+def test_calc_information_ratio_series_with_dataframe_benchmark():
+    index = pd.date_range("2026-01-01", periods=4, freq="D")
+    returns = pd.Series([0.03, 0.01, -0.02, 0.04], index=index)
+    benchmark = pd.DataFrame(
+        {
+            "bench_a": [0.01, 0.0, -0.01, 0.02],
+            "bench_b": [0.02, 0.01, 0.0, 0.01],
+        },
+        index=index,
+    )
+
+    actual = returns.calc_information_ratio(benchmark)
+    difference = benchmark.rsub(returns, axis="index")
     expected = difference.mean() / difference.std(ddof=1)
 
     pd.testing.assert_series_equal(actual, expected)


### PR DESCRIPTION
Supersedes #328, which could not be pushed to: its head fork is
organization-owned, so "allow edits by maintainers" does not grant push
access. The original commit by @wolfgang-aura is carried over unchanged.

`calc_prob_mom` and `calc_information_ratio` both subtracted the benchmark
with a bare `-`. Between a DataFrame and a Series that aligns the Series
against the frame's *columns*, so a date-indexed benchmark produced an
all-NaN frame the size of the calendar plus the column labels. #328 fixed
the DataFrame-returns-against-Series-benchmark shape in `calc_prob_mom`.

This adds the mirror shape. `series.calc_prob_mom(dataframe)` returned an
all-NaN Series over the union of dates and column labels, and the root cause
is in `calc_information_ratio`, which `calc_prob_mom` calls, so the two
disagreed on the same inputs.

The same `isinstance` pair had been copied between the two functions, and
this is the third time the same class of bug has been patched that way
(#310, #324, #328). Both now go through one `_diff_returns` helper that
handles either orientation.

`to_excess_returns` carries a variant of the same branch, but its second
argument is a risk-free rate, so the mirror shape is not meaningful there
and it is left alone.

Three tests added on top of #328's two. Two of them fail against #328's head
and pass here. The third pins the DataFrame-against-DataFrame return type,
which #328 deliberately changed from a bare ndarray to a labelled Series
without covering it.

`calc_prob_mom` still raises `AttributeError` on ndarray input, as it does on
`master` — it calls `returns.calc_information_ratio`, a `PandasObject`
method, so that shape has never worked.
