### PR TITLE
Infer Sortino periods before validating risk-free rates

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2454,14 +2454,15 @@ def calc_sortino_ratio(returns, rf=0.0, nperiods=None, annualize=True):
         * returns (Series or DataFrame): Returns
         * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed in yearly (annualized) terms or return series.
         * nperiods (int): Number of periods used for annualization. Must be
-            provided if rf is non-zero and rf is not a price series
+            provided or inferable if rf is a non-zero scalar
 
     """
-    if isinstance(rf, float) and rf != 0 and nperiods is None:
-        raise ValueError("nperiods must be set if rf != 0 and rf is not a price series")
-
+    # An inferable return frequency is sufficient to deannualize a scalar rate.
     if nperiods is None:
         nperiods = infer_nperiods(returns)
+
+    if isinstance(rf, float) and rf != 0 and nperiods is None:
+        raise ValueError("nperiods must be set or inferable if rf is a non-zero scalar")
 
     er = returns.to_excess_returns(rf, nperiods=nperiods)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -710,6 +710,41 @@ def test_calc_sortino_ratio(df):
     )
 
 
+def test_calc_sortino_ratio_infers_periods_before_deannualizing_risk_free_rate():
+    """Infer a return frequency before validating an annualized scalar rate."""
+    index = pd.date_range("2025-01-01", periods=20, freq="B")
+    series = pd.Series(np.linspace(-0.02, 0.03, 20), index=index, name="strategy")
+    frame = pd.DataFrame({"strategy": series, "scaled": series * 0.8})
+    rf = 0.05
+    nperiods = 252
+
+    # Calculate the per-period hurdle directly so the expected ratios do not
+    # depend on the frequency-inference or deannualization paths under test.
+    period_rf = (1.0 + rf) ** (1.0 / nperiods) - 1.0
+    for returns in (series, frame):
+        excess_returns = returns - period_rf
+        downside_deviation = np.sqrt((excess_returns.clip(upper=0.0) ** 2).mean())
+        expected = excess_returns.mean() / downside_deviation * np.sqrt(nperiods)
+
+        assert np.allclose(ffn.calc_sortino_ratio(returns, rf=rf), expected)
+        for result in (
+            returns.calc_sortino_ratio(rf=rf),
+            returns.calc_sortino(rf=rf),
+        ):
+            assert isinstance(result, (float, pd.Series))
+            assert np.allclose(result, expected)
+
+
+def test_calc_sortino_ratio_requires_periods_for_uninferrable_scalar_rate():
+    """Reject an annualized scalar rate when no period count can be inferred."""
+    returns = pd.Series([-0.02, 0.01, 0.03, -0.01])
+
+    with np.testing.assert_raises(ValueError):
+        ffn.calc_sortino_ratio(returns, rf=0.05)
+    with np.testing.assert_raises(ValueError):
+        returns.calc_sortino_ratio(rf=0.05)
+
+
 def test_calc_sortino_ratio_is_order_invariant():
     # Both the mean and the downside deviation are symmetric functions of the
     # sample, so reordering the same returns must not change the ratio.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -737,7 +737,9 @@ def test_calc_sortino_ratio_infers_periods_before_deannualizing_risk_free_rate()
 
 def test_calc_sortino_ratio_requires_periods_for_uninferrable_scalar_rate():
     """Reject an annualized scalar rate when no period count can be inferred."""
-    returns = pd.Series([-0.02, 0.01, 0.03, -0.01])
+    returns = pd.Series(
+        [-0.02, 0.01, 0.03, -0.01], index=["a", "b", "c", "d"]
+    )
 
     with np.testing.assert_raises(ValueError):
         ffn.calc_sortino_ratio(returns, rf=0.05)


### PR DESCRIPTION
## Summary

Let `calc_sortino_ratio` infer `nperiods` from an inferable return index before deciding whether a nonzero annualized scalar risk-free rate lacks the period count needed for deannualization.

For 20 business-daily returns ranging linearly from `-0.02` to `0.03`, `calc_sharpe(..., rf=0.05)` infers 252 periods and succeeds, while `calc_sortino_ratio(..., rf=0.05)` raises `ValueError` before reaching its existing `infer_nperiods` call. Supplying `nperiods=252` explicitly succeeds through both public paths and returns `9.6284655354`.

## Behavior

For Series and DataFrame returns with an inferable frequency, a nonzero annualized scalar risk-free rate now uses that inferred period count through the module function and both pandas method names. Inputs whose period count is neither supplied nor inferable still raise `ValueError`. The public signature, explicit-period behavior, Sortino formula, risk-free Series handling, and annualization convention are unchanged.

## Regression evidence

- **Fail before:** With only the two deterministic regression tests added, the inferable business-daily case failed at the premature scalar-risk-free guard while the then-current uninferrable-index control passed locally (`1 failed, 1 passed, 83 deselected`). After publication, pandas 1.5.3 exposed that the control's default `RangeIndex` was version-dependent, so its fixture now uses stable string labels without changing the expected contract.
- **Independent expectation:** Deannualizing `0.05` as `(1.05 ** (1 / 252)) - 1 = 0.0001936305065`, then independently applying `mean(excess) / sqrt(mean(min(excess, 0) ** 2)) * sqrt(252)`, gives `9.6284655354` for the Series and `[9.6284655354, 9.4993041252]` for the two-column DataFrame.
- **Pass after:** After moving frequency inference before the existing guard, both focused regressions pass through the module function, `calc_sortino_ratio` pandas method, and `calc_sortino` alias (`2 passed`). The corrected uninferrable-index regression also passes in the repository's pandas 1.5.3/NumPy 1.26.4 compatibility environment.
- **Unchanged controls:** Explicit periods, uninferrable-index rejection, zero scalar rates, Series risk-free inputs, annualized and unannualized results, and Series/DataFrame return shapes all pass in the product matrix and complete suites.

## Verification

- Focused Sortino regressions: 2 passed.
- Complete affected core module: 85 passed.
- Native lint and formatting checks: passed, with 0 new Ruff diagnostics and 6 documented inherited test-file findings left untouched.
- Changed-line Pyright 1.1.411: 0 unapproved diagnostics.
- Final native repository suite: 112 passed with 64% branch coverage.
- Legacy compatibility reproduction: the corrected regression passed with pandas 1.5.3 and NumPy 1.26.4.

## Scope

Changed files are limited to `ffn/core.py`, `tests/test_core.py`

Out of scope: Changing the Sortino formula, downside-deviation convention, risk-free Series alignment, `PerformanceStats` risk-free price convention, frequency inference itself, or scalar numeric-type expansion.
