### PR TITLE
Rebase each series from its first valid price

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1231,17 +1231,18 @@ def to_price_index(returns, start=100):
 
 def rebase(prices, value=100):
     """
-    Rebase all series to a given intial value.
+    Rebase each price series to a given initial value.
 
-    This makes comparing/plotting different series
-    together easier.
+    Each series uses its first non-missing price as the baseline. Missing
+    prices remain missing in the returned object.
 
     Args:
-        * prices: Expects a price series
+        * prices: Expects a price Series or DataFrame
         * value (number): starting value for all series.
 
     """
-    return prices / prices.iloc[0] * value
+    # Backfill only the baseline lookup so returned missing prices stay missing.
+    return prices / prices.bfill().iloc[0] * value
 
 
 def calc_perf_stats(prices, risk_free_rate=0.0, annualization_factor=252):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -225,6 +225,56 @@ def test_rebase(df):
     aae(actual["C"].iloc[9], 101.199, 3)
 
 
+def test_rebase_uses_each_columns_first_valid_price():
+    """Rebase every DataFrame column from its own first observed price."""
+    index = pd.date_range("2026-01-01", periods=4, freq="D")
+    prices = pd.DataFrame(
+        {
+            "complete": [100.0, 110.0, 121.0, 133.1],
+            "leading_gap": [np.nan, 50.0, 55.0, 60.5],
+            "internal_gap": [20.0, np.nan, 22.0, 24.2],
+            "all_missing": [np.nan, np.nan, np.nan, np.nan],
+        },
+        index=index,
+    )
+    expected = pd.DataFrame(
+        {
+            "complete": [100.0, 110.0, 121.0, 133.1],
+            "leading_gap": [np.nan, 100.0, 110.0, 121.0],
+            "internal_gap": [100.0, np.nan, 110.0, 121.0],
+            "all_missing": [np.nan, np.nan, np.nan, np.nan],
+        },
+        index=index,
+    )
+
+    module_result = ffn.rebase(prices)
+    method_result = prices.rebase()
+
+    assert isinstance(module_result, pd.DataFrame)
+    assert isinstance(method_result, pd.DataFrame)
+    pd.testing.assert_frame_equal(module_result, expected)
+    pd.testing.assert_frame_equal(method_result, expected)
+
+
+def test_rebase_nullable_series_uses_first_valid_price():
+    """Preserve nullable gaps while rebasing from the first observed price."""
+    index = pd.date_range("2026-01-01", periods=4, freq="D")
+    prices = pd.Series(
+        [pd.NA, 50.0, 55.0, 60.5], index=index, dtype="Float64", name="asset"
+    )
+    expected = pd.Series(
+        [pd.NA, 100.0, 110.0, 121.0], index=index, dtype="Float64", name="asset"
+    )
+
+    module_result = ffn.rebase(prices)
+    method_result = prices.rebase()
+
+    assert isinstance(module_result, pd.Series)
+    assert isinstance(method_result, pd.Series)
+    pd.testing.assert_series_equal(module_result, expected)
+    pd.testing.assert_series_equal(method_result, expected)
+
+
 def test_to_drawdown_series_ts(ts):
     data = ts
     actual = data.to_drawdown_series()


### PR DESCRIPTION
## Summary

Rebase every Series or DataFrame column from its own first non-missing price while retaining leading and internal missing positions in the returned object.

In a two-column price frame, an early asset starts at `100`, while a later asset is `[NaN, 50, 55, 60.5]`. The current `rebase` divides every column by the first row, so the later asset becomes all NaN. The independent per-column result is `[NaN, 100, 110, 121]`; the complete early asset remains `[100, 110, 121, 133.1]`.

## Behavior

Series and each DataFrame column now use their own first non-missing price as the requested baseline through both `ffn.rebase(...)` and the pandas `rebase(...)` method. Leading, internal, and all-missing positions remain missing; labels, order, names, nullable dtype, the public signature and default, and complete-history results remain unchanged.

## Regression evidence

- **Fail before:** With only the two approved deterministic regressions added, both failed against unchanged production code (`2 failed, 90 deselected`). The mixed DataFrame regression showed the leading-gap column was 75% different because its three observed values became NaN; the nullable Series regression showed the same 75% mismatch in its missing-value mask. Both failures occurred on the module-level call before the equivalent pandas-method assertion, proving the shared denominator defect rather than a method-registration difference.
- **Independent expectation:** For each price series `p`, divide the original values by `p.dropna().iloc[0]` and multiply by the requested baseline. This preserves missing positions and makes the first observed price exactly the baseline.
- **Pass after:** With the denominator derived from each series's first non-missing value, both exact regressions pass through the module-level and pandas-method paths (`2 passed`). The mixed DataFrame returns the independently expected complete, leading-gap, internal-gap, and all-missing columns, while the nullable Series preserves its `Float64` dtype, name, index, and leading `pd.NA`. Existing complete-history behavior and the private unchanged-control matrix also pass.

## Verification

- Differential Ruff: `0` new diagnostics and `6` inherited diagnostics left untouched.
- Changed-line Pyright 1.1.411: `0` unapproved diagnostics; `1,255` inherited or indirect diagnostics left untouched.
- Baseline-aware formatting: `ffn/core.py` strictly formatted; `tests/test_core.py` retained only accepted upstream format debt, with the added block unchanged by the formatter.
- Focused regressions: `2 passed`.
- Complete affected core module: `92 passed`.
- Native lint and formatting: passed (`5 files already formatted`).
- Final native repository suite: `119 passed` with 64% branch coverage.
- Packaging and documentation builds: not applicable because no metadata, dependency, packaging, or documentation file changed; notebook callers require no content change.
- `git diff --check`: passed. The ignored `.coverage`, `coverage.xml`, and `python_junit.xml` outputs were confirmed and removed after the run.

## Scope

Changed files are limited to `ffn/core.py`, `tests/test_core.py`

Out of scope: Changing `to_price_index`, `calc_total_return`, `calc_cagr`, fill policy, index order, or the meaning of an all-missing or zero-baseline series beyond preserving current undefined behavior.