### PR TITLE
Preserve missing gaps in log returns

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1169,7 +1169,8 @@ def to_log_returns(prices):
         * prices: Expects a price series
 
     """
-    return np.log1p(prices.pct_change())
+    # A return requires observed prices at both adjacent positions.
+    return np.log1p(prices.pct_change(fill_method=None))
 
 
 def to_price_index(returns, start=100):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,6 +118,50 @@ def test_to_log_returns_df(df):
     aae(actual["C"].iloc[9], 0.004, 3)
 
 
+def test_to_log_returns_preserves_dataframe_missing_gaps():
+    """Require both adjacent prices before calculating each log return."""
+    index = pd.date_range("2026-01-01", periods=4, freq="D")
+    prices = pd.DataFrame(
+        {
+            "complete": [100.0, 110.0, 121.0, 133.1],
+            "leading_gap": [np.nan, 50.0, 55.0, 60.5],
+            "internal_gap": [20.0, np.nan, 22.0, 24.2],
+            "trailing_gap": [30.0, 33.0, np.nan, np.nan],
+            "all_missing": [np.nan, np.nan, np.nan, np.nan],
+        },
+        index=index,
+    )
+    change = np.log(1.1)
+    expected = pd.DataFrame(
+        {
+            "complete": [np.nan, change, change, change],
+            "leading_gap": [np.nan, np.nan, change, change],
+            "internal_gap": [np.nan, np.nan, np.nan, change],
+            "trailing_gap": [np.nan, change, np.nan, np.nan],
+            "all_missing": [np.nan, np.nan, np.nan, np.nan],
+        },
+        index=index,
+    )
+
+    pd.testing.assert_frame_equal(ffn.to_log_returns(prices), expected)
+    pd.testing.assert_frame_equal(prices.to_log_returns(), expected)
+
+
+def test_to_log_returns_preserves_nullable_series_missing_gaps():
+    """Preserve nullable missing prices instead of filling across them."""
+    index = pd.date_range("2026-01-01", periods=4, freq="D")
+    prices = pd.Series([100.0, pd.NA, 110.0, 121.0], index=index, dtype="Float64", name="asset")
+    expected = pd.Series(
+        [pd.NA, pd.NA, pd.NA, np.log(1.1)],
+        index=index,
+        dtype="Float64",
+        name="asset",
+    )
+
+    pd.testing.assert_series_equal(ffn.to_log_returns(prices), expected)
+    pd.testing.assert_series_equal(prices.to_log_returns(), expected)
+
+
 def test_to_price_index(df):
     data = df
     rets = data.to_returns()


### PR DESCRIPTION
## Summary

Prevent `to_log_returns` from forward-filling missing prices so arithmetic and log-return conversions use the same observable price pairs.

For prices `[100.0, NaN, 110.0]`, accepted code returns log returns `[NaN, 0.0, 0.0953101798]`, fabricating both a zero return and a bridge return across the gap; direct `log(prices / prices.shift(1))` returns `[NaN, NaN, NaN]`.

## Behavior

A return exists only when both adjacent prices are observed. Preserve Series/DataFrame shape, labels, names, and module-level/pandas-method parity without filling, dropping, or bridging prices.

## Regression evidence

Fail-before returned invented zero and bridge returns and failed both new regressions; after explicitly disabling fill, both regressions pass against independently constructed expected Series/DataFrame objects while complete-data controls remain green.

## Verification

- Focused regression: Before the production fix, both new tests failed (`2 failed, 92 deselected`) with the expected missingness mismatch and implicit-`pad` warnings; after the fix, both passed (`2 passed`).
- Complete affected subsystem: All `94` tests in `tests/test_core.py` passed on the final source.
- Final full suite: Native `make test` passed all `121` tests with 64% branch coverage.
- Native `make lint` passed; differential Ruff found zero new diagnostics, and changed-line Pyright found zero unapproved diagnostics.
- The pandas 1.5.3/NumPy 1.26.4 module/method compatibility probe passed.
- The v1.2.1 source and wheel distributions built successfully and passed `twine check`.

## Scope

Changed files are limited to `ffn/core.py` and `tests/test_core.py`.

Out of scope: Changing arithmetic returns, adding a general fill option, dropping observations, sorting or filling input, changing first-return behavior, defining new zero/negative/non-finite price policy, or modifying price-index reconstruction or other performance-statistics behavior.