### PR TITLE
Use valid endpoints in performance statistics

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -192,6 +192,13 @@ class PerformanceStats:
         self.start = obj.index[0]
         self.end = obj.index[-1]
 
+        # Keep full-period fields on observed raw prices; resampling can alter intraday endpoints.
+        observed_prices = obj.dropna()
+        if len(observed_prices) > 1:
+            self.start = observed_prices.index[0]
+            self.end = observed_prices.index[-1]
+            self.total_return = observed_prices.iloc[-1] / observed_prices.iloc[0] - 1
+
         # save daily prices for future use
         self.daily_prices = obj.resample("D").last()
         # resample('D') imputes na values for any day that didn't have a price
@@ -223,11 +230,6 @@ class PerformanceStats:
         if len(r) < 2:
             return
 
-        # Keep full-period fields on observed raw prices; resampling can alter intraday endpoints.
-        observed_prices = obj.dropna()
-        self.start = observed_prices.index[0]
-        self.end = observed_prices.index[-1]
-
         # Auto-infer annualization factor from data frequency when not explicitly provided
         if self._annualization_factor_override is None:
             inferred = infer_nperiods(r)
@@ -251,8 +253,6 @@ class PerformanceStats:
 
             self.best_day = r.max()
             self.worst_day = r.min()
-
-        self.total_return = observed_prices.iloc[-1] / observed_prices.iloc[0] - 1
 
         self.cagr = calc_cagr(dp)
         self.incep = self.cagr

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -40,7 +40,8 @@ class PerformanceStats:
     statistics.
 
     Args:
-        * prices (Series): A price series.
+        * prices (Series): A price series. Unavailable outer observations are excluded from
+            endpoint statistics when total return is available.
         * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ used in various calculation. Should be
             expressed as a yearly (annualized) return if it is a float. Otherwise
             rf should be a *price* series — it is converted internally with
@@ -222,6 +223,11 @@ class PerformanceStats:
         if len(r) < 2:
             return
 
+        # Keep full-period fields on observed raw prices; resampling can alter intraday endpoints.
+        observed_prices = obj.dropna()
+        self.start = observed_prices.index[0]
+        self.end = observed_prices.index[-1]
+
         # Auto-infer annualization factor from data frequency when not explicitly provided
         if self._annualization_factor_override is None:
             inferred = infer_nperiods(r)
@@ -246,7 +252,7 @@ class PerformanceStats:
             self.best_day = r.max()
             self.worst_day = r.min()
 
-        self.total_return = obj.iloc[-1] / obj.iloc[0] - 1
+        self.total_return = observed_prices.iloc[-1] / observed_prices.iloc[0] - 1
 
         self.cagr = calc_cagr(dp)
         self.incep = self.cagr

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1544,6 +1544,47 @@ def test_performance_stats(df):
     assert num_stats == num_unique_stats
 
 
+def test_performance_stats_uses_observed_price_endpoints():
+    """Use observed outer prices for endpoint dates and total return."""
+    dates = pd.date_range("2025-01-01", periods=4, tz="UTC")
+    price_series = (
+        pd.Series([np.nan, 100.0, 105.0], index=dates[:3]),
+        pd.Series([100.0, 105.0, np.nan], index=dates[:3]),
+        pd.Series([pd.NA, 100.0, 105.0, pd.NA], index=dates, dtype="Float64"),
+    )
+
+    for prices in price_series:
+        observed = prices.dropna()
+        expected_total_return = observed.iloc[-1] / observed.iloc[0] - 1
+        results = (
+            ffn.PerformanceStats(prices),
+            ffn.calc_perf_stats(prices),
+            ffn.calc_stats(prices),
+            prices.calc_perf_stats(),
+            prices.calc_stats(),
+        )
+
+        for stats in results:
+            assert isinstance(stats, ffn.PerformanceStats)
+            assert stats.start == observed.index[0]
+            assert stats.end == observed.index[-1]
+            assert stats.total_return == expected_total_return
+
+
+def test_performance_stats_date_range_reset_uses_observed_endpoints():
+    """Restore observed endpoints when resetting a statistics date range."""
+    dates = pd.date_range("2025-01-01", periods=5)
+    prices = pd.Series([np.nan, 100.0, 105.0, 110.0, np.nan], index=dates)
+    stats = ffn.PerformanceStats(prices)
+
+    stats.set_date_range(start=dates[2], end=dates[3])
+    stats.set_date_range()
+
+    assert stats.start == dates[1]
+    assert stats.end == dates[3]
+    assert stats.total_return == 110.0 / 100.0 - 1
+
+
 def test_group_stats_calc_stats(df):
     gs = df.calc_stats()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1551,6 +1551,7 @@ def test_performance_stats_uses_observed_price_endpoints():
         pd.Series([np.nan, 100.0, 105.0], index=dates[:3]),
         pd.Series([100.0, 105.0, np.nan], index=dates[:3]),
         pd.Series([pd.NA, 100.0, 105.0, pd.NA], index=dates, dtype="Float64"),
+        pd.Series([np.nan, 100.0, 105.0, np.nan], index=pd.date_range("2025-01-01 09:00", periods=4, freq="h", tz="UTC")),
     )
 
     for prices in price_series:


### PR DESCRIPTION
## Summary

Make `PerformanceStats` report `start`, `end`, and `total_return` from the first and last observed raw input prices when outer prices are missing, without changing its existing resampling, CAGR, internal-gap, or clean intraday behavior.

In a 260-business-day price series growing 0.05% per observation, a leading missing price produces a missing-date `start` and `total_return=NaN` while CAGR remains finite; a trailing missing price analogously produces a missing-date `end` and `total_return=NaN`. Trimming only unavailable outer observations gives the independently expected endpoints and total returns.

## Behavior

`start` and `end` identify observations that supplied prices, and `total_return` equals `last_observed_raw_price / first_observed_raw_price - 1`. Preserve input ordering, internal gaps, raw intraday endpoints, the established daily resampling used by CAGR and other statistics, and every statistic not derived directly from these three fields.

## Regression evidence

Before the production change, both permanent regressions failed for the intended endpoint mismatch (`2 failed, 92 deselected`). After the change, they pass through all public Series paths and date-range reset (`2 passed`), and the independently derived observed endpoints and total return agree in both compatibility bands. Complete, internal-gap, subdaily, annualization-override, and one-valid controls retain their established behavior.

## Verification

- Focused regression: The two new tests failed before the production change (`2 failed, 92 deselected`) and pass on the final source (`2 passed`), covering all five public Series entry paths plus date-range reset.
- Complete affected subsystem: All `96` tests in `tests/test_core.py` pass on the rebased source.
- Final full suite: Required because `calc_stats` and `calc_perf_stats` are pandas extensions; native `make test` passes all `123` tests with 65% branch coverage.
- Static, documentation, API, dependency, or build checks: Native `make lint` passes. Differential Ruff reports zero new and six inherited diagnostics; `ffn/core.py` is formatter-clean and `tests/test_core.py` retains only accepted format debt. Changed-line Pyright reports zero unapproved diagnostics and 1,255 inherited or indirect diagnostics. Format-new preview and execution found no added Python files. The downstream benchmark integration passes both dataset sizes for both `calc_perf_stats` and `calc_stats` (`4 passed`); read-only notebook inspection found only complete-endpoint generated output, so no record update or build is required. Public signatures, imports, exports, and dependencies are unchanged.

## Scope

Changed files are limited to `ffn/core.py`, `tests/test_core.py`

Out of scope: Filling internal gaps; sorting descending input; changing CAGR, resampling, or annualization formulas; changing standalone `calc_total_return` or `calc_cagr`; and defining empty, all-missing, or one-valid input policy.