### PR TITLE
Support NumPy floating risk-free rates

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -30,6 +30,7 @@ else:
 
 # module level variable, can be different for non traditional markets (eg. crypto - 360)
 TRADING_DAYS_PER_YEAR = 252
+_FLOATING_SCALAR_TYPES = (float, np.floating)
 
 
 class PerformanceStats:
@@ -42,8 +43,8 @@ class PerformanceStats:
     Args:
         * prices (Series): A price series. Unavailable outer observations are excluded from
             endpoint statistics when total return is available.
-        * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ used in various calculation. Should be
-            expressed as a yearly (annualized) return if it is a float. Otherwise
+        * rf (float, np.floating, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ used in various calculation. Should be
+            expressed as a yearly (annualized) return if it is a floating scalar. Otherwise
             rf should be a *price* series — it is converted internally with
             to_returns(). Note this differs from calc_sharpe and
             calc_sortino_ratio, which take rf as a return series. Passing a
@@ -81,7 +82,7 @@ class PerformanceStats:
         Affects only this instance of the PerformanceStats.
 
         Args:
-            * rf (float, Series): Annual `risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_,
+            * rf (float, np.floating, Series): Annual `risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_,
                 or a risk-free *price* series (not returns)
         """
         self.rf = rf
@@ -244,7 +245,7 @@ class PerformanceStats:
             self.daily_mean = r.mean() * self.annualization_factor
             self.daily_vol = r.std(ddof=1) * np.sqrt(self.annualization_factor)
 
-            if isinstance(self.rf, float):
+            if isinstance(self.rf, _FLOATING_SCALAR_TYPES):
                 self.daily_sharpe = r.calc_sharpe(rf=self.rf, nperiods=self.annualization_factor)
                 self.daily_sortino = calc_sortino_ratio(r, rf=self.rf, nperiods=self.annualization_factor)
             # rf is a price series
@@ -292,7 +293,7 @@ class PerformanceStats:
             self.monthly_mean = mr.mean() * 12
             self.monthly_vol = mr.std(ddof=1) * np.sqrt(12)
 
-            if isinstance(self.rf, float):
+            if isinstance(self.rf, _FLOATING_SCALAR_TYPES):
                 self.monthly_sharpe = mr.calc_sharpe(rf=self.rf, nperiods=12)
                 self.monthly_sortino = calc_sortino_ratio(mr, rf=self.rf, nperiods=12)
             # rf is a price series
@@ -382,8 +383,7 @@ class PerformanceStats:
             self.yearly_mean = yr.mean()
             self.yearly_vol = yr.std(ddof=1)
 
-            # if type(self.rf) is float:
-            if isinstance(self.rf, float):
+            if isinstance(self.rf, _FLOATING_SCALAR_TYPES):
                 if self.yearly_vol > 0:
                     self.yearly_sharpe = yr.calc_sharpe(rf=self.rf, nperiods=1)
                 self.yearly_sortino = calc_sortino_ratio(yr, rf=self.rf, nperiods=1)
@@ -514,7 +514,7 @@ class PerformanceStats:
         provided.
         """
         print(f"Stats for {self.name} from {self.start} - {self.end}")
-        if isinstance(self.rf, float):
+        if isinstance(self.rf, _FLOATING_SCALAR_TYPES):
             print(f"Annual risk-free rate considered: {fmtp(self.rf)}")
         print("Summary:")
         data = [
@@ -716,7 +716,7 @@ class PerformanceStats:
             k, n, _ = stat
 
             # blank row
-            if k is None or k == "rf" and not isinstance(self.rf, float):
+            if k is None or k == "rf" and not isinstance(self.rf, _FLOATING_SCALAR_TYPES):
                 continue
 
             if n in short_names:
@@ -752,7 +752,7 @@ class PerformanceStats:
                 row = [""] * len(data[0])
                 data.append(sep.join(row))
                 continue
-            elif k == "rf" and not isinstance(self.rf, float):
+            elif k == "rf" and not isinstance(self.rf, _FLOATING_SCALAR_TYPES):
                 continue
 
             row = [n]
@@ -945,7 +945,7 @@ class GroupStats(dict):
         this GroupStats object.
 
         Args:
-            * rf (float, Series): Annual risk-free rate or risk-free rate *price*
+            * rf (float, np.floating, Series): Annual risk-free rate or risk-free rate *price*
                 series (not returns)
         """
 
@@ -993,7 +993,7 @@ class GroupStats(dict):
                 raw = getattr(self[key], k)
 
                 # if rf is a series print nan
-                if k == "rf" and not isinstance(raw, float):
+                if k == "rf" and not isinstance(raw, _FLOATING_SCALAR_TYPES):
                     row.append(np.nan)
                 elif f is None:
                     row.append(raw)
@@ -1263,7 +1263,7 @@ def calc_perf_stats(prices, risk_free_rate=0.0, annualization_factor=252):
 
     Args:
         * prices (Series): Series of prices
-        * risk_free_rate (float, Series): Annual risk-free rate or risk-free rate price series
+        * risk_free_rate (float, np.floating, Series): Annual risk-free rate or risk-free rate price series
         * annualization_factor (int): Annualizing factor. Default is 252 (trading days)
 
     """
@@ -1443,12 +1443,12 @@ def calc_sharpe(returns, rf=0.0, nperiods=None, annualize=True):
     Calculates the `Sharpe ratio <https://www.investopedia.com/terms/s/sharperatio.asp>`_
     (see `Sharpe vs. Sortino <https://www.investopedia.com/ask/answers/010815/what-difference-between-sharpe-ratio-and-sortino-ratio.asp>`_).
 
-    If rf is non-zero and a float, you must specify nperiods. In this case, rf is assumed
+    If rf is a non-zero floating scalar, you must specify nperiods. In this case, rf is assumed
     to be expressed in yearly (annualized) terms.
 
     Args:
         * returns (Series, DataFrame): Input return series
-        * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed as a yearly (annualized) return or *return*
+        * rf (float, np.floating, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed as a yearly (annualized) return or *return*
             series (unlike PerformanceStats, which takes rf as a price series)
         * nperiods (int): Frequency of returns (252 for daily, 12 for monthly,
             etc.)
@@ -1457,7 +1457,7 @@ def calc_sharpe(returns, rf=0.0, nperiods=None, annualize=True):
     if nperiods is None:
         nperiods = infer_nperiods(returns)
 
-    if isinstance(rf, float) and rf != 0 and nperiods is None:
+    if isinstance(rf, _FLOATING_SCALAR_TYPES) and rf != 0 and nperiods is None:
         raise ValueError("Must provide nperiods if rf != 0")
 
     er = returns.to_excess_returns(rf, nperiods=nperiods)
@@ -2477,7 +2477,7 @@ def calc_sortino_ratio(returns, rf=0.0, nperiods=None, annualize=True):
 
     Args:
         * returns (Series or DataFrame): Returns
-        * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed in yearly (annualized) terms or return series.
+        * rf (float, np.floating, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed in yearly (annualized) terms or return series.
         * nperiods (int): Number of periods used for annualization. Must be
             provided or inferable if rf is a non-zero scalar
 
@@ -2486,7 +2486,7 @@ def calc_sortino_ratio(returns, rf=0.0, nperiods=None, annualize=True):
     if nperiods is None:
         nperiods = infer_nperiods(returns)
 
-    if isinstance(rf, float) and rf != 0 and nperiods is None:
+    if isinstance(rf, _FLOATING_SCALAR_TYPES) and rf != 0 and nperiods is None:
         raise ValueError("nperiods must be set or inferable if rf is a non-zero scalar")
 
     er = returns.to_excess_returns(rf, nperiods=nperiods)
@@ -2513,9 +2513,9 @@ def to_excess_returns(returns, rf, nperiods=None):
 
     Args:
         * returns (Series, DataFrame): Returns
-        * rf (float, Series): `Risk-Free rate(s) <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed in annualized term or return series
+        * rf (float, np.floating, Series): `Risk-Free rate(s) <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed in annualized term or return series
         * nperiods (int): Optional. If provided, will convert rf to different
-            frequency using deannualize only if rf is a float
+            frequency using deannualize only if rf is a floating scalar
     Returns:
         * excess_returns (Series, DataFrame): Returns - rf
 
@@ -2523,8 +2523,11 @@ def to_excess_returns(returns, rf, nperiods=None):
     if nperiods is None:
         nperiods = infer_nperiods(returns)
 
-    if isinstance(rf, float) and nperiods is not None:
-        _rf = deannualize(rf, nperiods)
+    if isinstance(rf, _FLOATING_SCALAR_TYPES) and nperiods is not None:
+        # Promote low-precision NumPy scalars before calculating a much smaller
+        # per-period rate, which could otherwise round to zero.
+        scalar_rf = float(rf.item()) if isinstance(rf, np.floating) else rf
+        _rf = deannualize(scalar_rf, nperiods)
     else:
         _rf = rf
 
@@ -2589,7 +2592,7 @@ def to_ulcer_performance_index(prices, rf=0.0, nperiods=None):
 
     Args:
         * prices (Series, DataFrame): Prices
-        * rf (float, Series): `Risk-free rate of return <https://www.investopedia.com/terms/r/risk-freerate.asp>`_. Assumed to be expressed in
+        * rf (float, np.floating, Series): `Risk-free rate of return <https://www.investopedia.com/terms/r/risk-freerate.asp>`_. Assumed to be expressed in
             yearly (annualized) terms or return series
         * nperiods (int): Used to deannualize rf if rf is provided (non-zero)
 
@@ -2597,7 +2600,7 @@ def to_ulcer_performance_index(prices, rf=0.0, nperiods=None):
     if nperiods is None:
         nperiods = infer_nperiods(prices)
 
-    if isinstance(rf, float) and rf != 0 and nperiods is None:
+    if isinstance(rf, _FLOATING_SCALAR_TYPES) and rf != 0 and nperiods is None:
         raise ValueError("nperiods must be set if rf != 0 and rf is not a price series")
 
     # to_ulcer_index carries the last known price across a gap, so fill here
@@ -2672,7 +2675,7 @@ def calc_deflated_sharpe_ratio(returns, trial_sharpe_ratios, rf=0.0, nperiods=No
         * returns (Series): Return series of the selected (best) trial.
         * trial_sharpe_ratios (Series, array-like): Sharpe ratios of all
             evaluated trials, e.g. as returned by :func:`calc_sharpe`.
-        * rf (float, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_
+        * rf (float, np.floating, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_
             expressed in yearly (annualized) terms or return series.
         * nperiods (int): Frequency of returns (252 for daily, 12 for
             monthly, etc.). Inferred from `returns` if not provided.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1446,6 +1446,165 @@ def test_to_excess_returns_dataframe_with_series_risk_free():
     )
 
 
+def test_numpy_floating_risk_free_rates_match_python_float():
+    """Apply annualized-rate semantics to every NumPy floating scalar."""
+    index = pd.date_range("2025-01-01", periods=20, freq="B")
+    series = pd.Series(np.linspace(-0.02, 0.03, 20), index=index, name="strategy")
+    frame = pd.DataFrame({"strategy": series, "scaled": series * 0.8})
+    prices = (1.0 + series).cumprod() * 100.0
+    annual_rate = 0.0625
+    nperiods = 252
+
+    for scalar_name in ("float16", "float32", "float64"):
+        risk_free = getattr(np, scalar_name)(annual_rate)
+        # Derive the per-period hurdle independently of ffn's type-dispatch and
+        # deannualization paths, using the exact value represented by each dtype.
+        period_rate = (1.0 + float(risk_free)) ** (1.0 / nperiods) - 1.0
+
+        for returns in (series, frame):
+            expected_excess = returns - period_rate
+            expected_sharpe = expected_excess.mean() / expected_excess.std(ddof=1) * np.sqrt(nperiods)
+            downside_deviation = np.sqrt((expected_excess.clip(upper=0.0) ** 2).mean())
+            expected_sortino = expected_excess.mean() / downside_deviation * np.sqrt(nperiods)
+
+            for actual in (
+                ffn.to_excess_returns(returns, risk_free, nperiods=nperiods),
+                returns.to_excess_returns(risk_free, nperiods=nperiods),
+                ffn.to_excess_returns(returns, risk_free),
+                returns.to_excess_returns(risk_free),
+            ):
+                assert (actual == expected_excess).to_numpy().all()
+
+            for actual in (
+                ffn.calc_sharpe(returns, rf=risk_free, nperiods=nperiods),
+                returns.calc_sharpe(rf=risk_free, nperiods=nperiods),
+                returns.calc_sharpe_ratio(rf=risk_free, nperiods=nperiods),
+                ffn.calc_sharpe(returns, rf=risk_free),
+                returns.calc_sharpe(rf=risk_free),
+                returns.calc_sharpe_ratio(rf=risk_free),
+            ):
+                if isinstance(actual, pd.Series):
+                    assert (actual == expected_sharpe).all()
+                else:
+                    assert actual == expected_sharpe
+
+            for actual in (
+                ffn.calc_sortino_ratio(returns, rf=risk_free, nperiods=nperiods),
+                returns.calc_sortino_ratio(rf=risk_free, nperiods=nperiods),
+                returns.calc_sortino(rf=risk_free, nperiods=nperiods),
+                ffn.calc_sortino_ratio(returns, rf=risk_free),
+                returns.calc_sortino_ratio(rf=risk_free),
+                returns.calc_sortino(rf=risk_free),
+            ):
+                if isinstance(actual, pd.Series):
+                    assert (actual == expected_sortino).all()
+                else:
+                    assert actual == expected_sortino
+
+        price_returns = prices.pct_change(fill_method=None)
+        expected_excess = price_returns - period_rate
+        drawdowns = prices / prices.cummax() - 1.0
+        ulcer_index = ((drawdowns * 100.0) ** 2).mean() ** 0.5
+        expected_upi = expected_excess.mean() * 100.0 / ulcer_index
+        aae(
+            ffn.to_ulcer_performance_index(prices, rf=risk_free, nperiods=nperiods),
+            expected_upi,
+        )
+        aae(
+            prices.to_ulcer_performance_index(rf=risk_free, nperiods=nperiods),
+            expected_upi,
+        )
+        aae(
+            ffn.to_ulcer_performance_index(prices, rf=risk_free),
+            expected_upi,
+        )
+        aae(
+            prices.to_ulcer_performance_index(rf=risk_free),
+            expected_upi,
+        )
+
+
+def test_numpy_floating_risk_free_rates_require_periods():
+    """Reject nonzero NumPy floating rates when periods are unavailable."""
+    # A non-datetime index leaves the observation frequency deliberately
+    # uninferrable, so each public ratio must require nperiods explicitly.
+    returns = pd.Series([-0.02, 0.01, 0.03, -0.01], index=["a", "b", "c", "d"])
+    prices = pd.Series([100.0, 98.0, 99.0, 102.0], index=["a", "b", "c", "d"])
+
+    for scalar_name in ("float16", "float32", "float64"):
+        risk_free = getattr(np, scalar_name)(0.0625)
+        with np.testing.assert_raises(ValueError):
+            ffn.calc_sharpe(returns, rf=risk_free)
+        with np.testing.assert_raises(ValueError):
+            ffn.calc_sortino_ratio(returns, rf=risk_free)
+        with np.testing.assert_raises(ValueError):
+            ffn.to_ulcer_performance_index(prices, rf=risk_free)
+
+
+def test_numpy_floating_risk_free_rates_work_in_stats():
+    """Keep NumPy floating rates on scalar statistics and output paths."""
+    import contextlib
+    import io
+
+    annual_rate = 0.0625
+    # Four years of business-daily prices exercise the daily, monthly, and
+    # yearly PerformanceStats risk-free branches in one deterministic sample.
+    index = pd.bdate_range("2020-01-02", periods=1000)
+    returns = np.tile([-0.0125, -0.00625, 0.003125, 0.009375, 0.015625], 200)
+    asset_a_prices = pd.Series(
+        (1.0 + returns).cumprod() * 100.0,
+        index=index,
+        name="asset_a",
+    )
+    prices = pd.DataFrame(
+        {
+            "asset_a": asset_a_prices,
+            "asset_b": (1.0 + returns * 0.8).cumprod() * 100.0,
+        },
+        index=index,
+    )
+    expected_stats = ffn.PerformanceStats(asset_a_prices, rf=annual_rate)
+
+    for scalar_name in ("float16", "float32", "float64"):
+        risk_free = getattr(np, scalar_name)(annual_rate)
+        stats = ffn.PerformanceStats(asset_a_prices, rf=risk_free)
+
+        for field in (
+            "daily_sharpe",
+            "daily_sortino",
+            "monthly_sharpe",
+            "monthly_sortino",
+            "yearly_sharpe",
+            "yearly_sortino",
+        ):
+            assert np.isclose(getattr(stats, field), getattr(expected_stats, field))
+
+        assert stats.stats["rf"] == risk_free
+        csv = stats.to_csv()
+        assert csv is not None
+        assert "Risk-free rate,6.25%" in csv
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            stats.display()
+        assert "Annual risk-free rate considered: 6.25%" in output.getvalue()
+
+        group = ffn.GroupStats(prices)
+        group.set_riskfree_rate(risk_free)
+        assert (group.stats.loc["rf"] == annual_rate).all()
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            group.display()
+        risk_free_row = next(line for line in output.getvalue().splitlines() if line.startswith("Risk-free rate"))
+        assert risk_free_row.split() == ["Risk-free", "rate", "6.25%", "6.25%"]
+
+        # Zero still exercises scalar classification even though its
+        # deannualized value is numerically unchanged.
+        zero_rate = getattr(np, scalar_name)(0.0)
+        zero_stats = ffn.PerformanceStats(asset_a_prices, rf=zero_rate)
+        expected_zero = ffn.PerformanceStats(asset_a_prices, rf=0.0)
+        assert zero_stats.daily_sharpe == expected_zero.daily_sharpe
+
+
 def test_set_riskfree_rate(df):
     r = df.to_returns()
 


### PR DESCRIPTION
## Summary

Define one private floating-scalar type tuple for Python `float` and NumPy `np.floating`, then use it consistently for annualized risk-free rates across the existing direct ratio, pandas-extension, `PerformanceStats`, `GroupStats`, and output paths.

On 260 business-daily returns and an exactly representable annual rate of `0.0625`, `np.float16` and `np.float32` bypass all current `isinstance(rf, float)` branches. `to_excess_returns` subtracts `0.0625` every day instead of the independently deannualized `0.00024060283631732737`; Sharpe is `-94.2311289756` instead of `2.5403891122`, Sortino is `-15.6547637448` instead of `4.0574051326`, and ulcer performance index is `-4.8655648907` instead of `0.1357500716`. `PerformanceStats` and `GroupStats.set_riskfree_rate` both raise `AttributeError` by sending either scalar down the price-series path. Equal Python `float` and `np.float64` values produce the expected results.

## Behavior

Python floating scalars and NumPy `float16`, `float32`, and `float64` scalars with equal represented values must select the same annualized-rate semantics. Preserve the distinct established conventions: direct functions take a scalar annual rate or a risk-free return Series, while `PerformanceStats` and `GroupStats` take a scalar annual rate or a risk-free price Series. Preserve Series/DataFrame shapes, labels, alignment, inferred and explicit annualization, output visibility, and module/pandas-method parity.

## Regression evidence

Confirmed on accepted `82ec67d2aa96593b844b4d235dad0047fccfb96f` in both supported local lanes: CPython 3.10.21 with pandas 2.3.3/NumPy 2.2.6 and pandas 1.5.3/NumPy 1.26.4. The deterministic values above were identical in both lanes. Zero-valued `np.float16` and `np.float32` also crash `PerformanceStats`, and a nonzero scalar on a stable uninferrable string index bypasses the clear `ValueError` raised for Python `float` and `np.float64`.

## Verification

- Focused regression: The three NumPy floating risk-free regressions passed after the final upstream refresh (`3 passed`).
- Complete affected subsystem: `tests/test_core.py` passed all `100` tests.
- Final full suite: Native `make test` passed all `127` tests with branch coverage and no test failures.
- Static, documentation, API, dependency, or build checks: `git diff --check` and native `make lint` passed; differential Ruff found `0` new and `6` inherited diagnostics; changed-line Pyright found `0` unapproved and `0` maintainer-authorized diagnostics. `ffn/core.py` is formatter-clean and `tests/test_core.py` retains only inherited format debt. No separate documentation, package, benchmark, or distribution check applies to this two-file implementation-and-test change.

## Scope

Changed files are limited to `ffn/core.py`, `tests/test_core.py`

Out of scope: Broadening the scalar domain to integers, NumPy integers, booleans, Decimal, Fraction, complex or arbitrary numeric-like objects; adding finite-value validation; changing scalar annualization, risk-free Series alignment, the `PerformanceStats` price-series convention, public signatures, frequency inference, or unrelated performance optimizations.