### PR TITLE
fix(data): restore forward filling with pandas 3

### DIFF
--- a/ffn/data.py
+++ b/ffn/data.py
@@ -91,7 +91,7 @@ def get(
         df = df.dropna()
 
     if forward_fill:
-        df = df.fillna(method="ffill")
+        df = df.ffill()
 
     if column_names:
         cnames = utils.parse_arg(column_names)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+import ffn
+
+
+def sample_provider(ticker, field):
+    prices = {"ABC": [np.nan, 10.0, np.nan, 12.0], "DEF": [20.0, np.nan, 22.0, 23.0]}
+    return pd.Series(prices[ticker], index=pd.date_range("2024-01-01", periods=4))
+
+
+@pytest.mark.parametrize("forward_fill", [False, True])
+@pytest.mark.parametrize("common_dates", [False, True])
+def test_get_forward_fill(forward_fill, common_dates):
+    result = ffn.get(
+        "ABC,DEF",
+        provider=sample_provider,
+        common_dates=common_dates,
+        forward_fill=forward_fill,
+        mrefresh=True,
+    )
+
+    if common_dates:
+        expected = pd.DataFrame({"abc": [12.0], "def": [23.0]}, index=pd.date_range("2024-01-04", periods=1))
+    else:
+        expected = pd.DataFrame(
+            {"abc": [np.nan, 10.0, 10.0 if forward_fill else np.nan, 12.0], "def": [20.0, 20.0 if forward_fill else np.nan, 22.0, 23.0]},
+            index=pd.date_range("2024-01-01", periods=4),
+        )
+    pd.testing.assert_frame_equal(result, expected, check_freq=False)


### PR DESCRIPTION
## Summary

`ffn.get(..., common_dates=False, forward_fill=True)` raises `TypeError` with pandas 3 because `fillna` no longer accepts `method`. Use `ffill()` so the documented option fills missing prices again.

The regression covers both values of `forward_fill` and `common_dates`, with separate gaps in two columns and a leading gap that must stay missing.

## Validation

- Regression before the fix: 2 failed, 2 passed.
- Full suite: 135 passed, 73.77% coverage, on Windows with Python 3.11.9 and pandas 3.0.5.
- Ruff check/format, sdist and wheel builds, and `check-dist -v --rebuild` passed.

## Post-Deploy Monitoring & Validation

No service deployment is involved. The offline loader regression checks the returned frame without fetching market data.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
