### PR TITLE
Preserve GroupStats risk-free rates across date ranges

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -810,6 +810,8 @@ class GroupStats(dict):
 
     def __init__(self, *prices, annualization_factor=None):
         self._annualization_factor_override = annualization_factor
+        # Preserve configuration when date-range updates rebuild the child statistics.
+        self._riskfree_rate = 0.0
         names = []
         for p in prices:
             if isinstance(p, pd.DataFrame):
@@ -863,7 +865,11 @@ class GroupStats(dict):
             full_data = data
         for c in data.columns:
             prc = full_data[c].dropna()
-            self[c] = PerformanceStats(prc, annualization_factor=self._annualization_factor_override)
+            self[c] = PerformanceStats(
+                prc,
+                rf=self._riskfree_rate,
+                annualization_factor=self._annualization_factor_override,
+            )
 
     def _stats(self):
         stats = [
@@ -954,6 +960,9 @@ class GroupStats(dict):
 
         # calculate stats for entire series
         self._update_stats()
+
+        # A failed recalculation must not become the default for later rebuilds.
+        self._riskfree_rate = rf
 
     def set_date_range(self, start=None, end=None):
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1715,6 +1715,78 @@ def test_set_riskfree_rate(df):
     aae(performanceStats.yearly_sharpe, groupStats["MSFT"].yearly_sharpe, 3)
 
 
+def test_group_stats_preserves_scalar_riskfree_rate_across_date_ranges():
+    """Preserve a scalar risk-free rate when GroupStats rebuilds its children."""
+    prices = pd.DataFrame(
+        {
+            "A": [100.0, 101.0, 99.0, 102.0, 104.0, 103.0, 106.0, 108.0],
+            "B": [80.0, 79.0, 81.0, 82.0, 81.0, 84.0, 83.0, 86.0],
+        },
+        index=pd.date_range("2024-01-01", periods=8),
+    )
+    annual_rate = 0.05
+    annualization_factor = 252
+    # Convert the annual scalar independently using the established compounding convention.
+    period_rate = (1.0 + annual_rate) ** (1.0 / annualization_factor) - 1.0
+    start = prices.index[2]
+    stats = ffn.GroupStats(prices, annualization_factor=annualization_factor)
+    stats.set_riskfree_rate(annual_rate)
+
+    # Exercise both a partial rebuild and the no-argument full-range reset.
+    # Derive the expected ratios without reusing ffn's risk-free helpers.
+    for range_start, windowed_prices in ((start, prices.loc[start:]), (None, prices)):
+        stats.set_date_range(start=range_start)
+
+        for name in ("A", "B"):
+            returns = windowed_prices[name].pct_change()
+            expected_sharpe = (returns - period_rate).mean() / returns.std(ddof=1) * np.sqrt(annualization_factor)
+            child = stats[name]
+            assert child is not None
+            assert child.rf == annual_rate
+            assert -1e-12 < child.daily_sharpe - expected_sharpe < 1e-12
+
+        assert (stats.stats.loc["rf"] == annual_rate).all()
+
+
+def test_group_stats_preserves_series_riskfree_rate_across_date_ranges():
+    """Preserve risk-free prices when GroupStats rebuilds its children."""
+    prices = pd.DataFrame(
+        {
+            "A": [100.0, 101.0, 99.0, 102.0, 104.0, 103.0, 106.0, 108.0],
+            "B": [80.0, 79.0, 81.0, 82.0, 81.0, 84.0, 83.0, 86.0],
+        },
+        index=pd.date_range("2024-01-01", periods=8),
+    )
+    annualization_factor = 252
+    risk_free_prices = pd.Series(
+        100.0 * np.cumprod(np.full(len(prices), 1.0 + 0.03 / annualization_factor)),
+        index=prices.index,
+        name="rf",
+    )
+    # Retain caller-owned input so the reconstruction can also prove non-mutation.
+    original_risk_free_prices = risk_free_prices.copy()
+    risk_free_returns = risk_free_prices.pct_change()
+    start = prices.index[2]
+    stats = ffn.GroupStats(prices, annualization_factor=annualization_factor)
+    stats.set_riskfree_rate(risk_free_prices)
+
+    # Exercise both a partial rebuild and the no-argument full-range reset.
+    # Derive the expected ratios without reusing ffn's risk-free helpers.
+    for range_start, windowed_prices in ((start, prices.loc[start:]), (None, prices)):
+        stats.set_date_range(start=range_start)
+
+        for name in ("A", "B"):
+            returns = windowed_prices[name].pct_change()
+            expected_sharpe = (returns - risk_free_returns).mean() / returns.std(ddof=1) * np.sqrt(annualization_factor)
+            child = stats[name]
+            assert child is not None
+            assert isinstance(child.rf, pd.Series)
+            pd.testing.assert_series_equal(child.rf, risk_free_prices)
+            assert -1e-12 < child.daily_sharpe - expected_sharpe < 1e-12
+
+    pd.testing.assert_series_equal(risk_free_prices, original_risk_free_prices)
+
+
 def test_performance_stats(df):
     ps = ffn.PerformanceStats(df["AAPL"])
 


### PR DESCRIPTION
## Summary

Preserve a configured scalar or price-Series risk-free rate when `GroupStats.set_date_range` rebuilds its child statistics.

After `set_riskfree_rate(0.05)`, two child statistics objects report `(0.05, 0.05)`; calling `set_date_range(...)` silently changes both to `(0.0, 0.0)` and recalculates ratios under a different financial assumption. In a deterministic 520-business-day sample, the first child's partial-range daily Sharpe was `1.510122793962022` instead of the independently reconstructed `0.41602391956232593` with the configured five-percent scalar rate. A three-percent risk-free price Series likewise produced `1.510122793962022` instead of `0.8374505569024521`.

## Behavior

Changing the reporting window must not change persistent risk-free state. Scalar annualized rates and price-Series rates retain their established, distinct conventions and existing index alignment. Each rebuilt child must use the same configured risk-free object while recalculating from its own windowed price calendar; a no-argument reset must restore the full price range without resetting the risk-free assumption.

## Regression evidence

On accepted `387cac7c95737c17914cfa8240b4bba10d7d6b9e`, the two permanent scalar and price-Series regressions both failed for the intended reason: a partial date-range rebuild replaced the configured risk-free state with `0.0`. With the minimal persistence fix, both pass across a partial window and a no-argument full-range reset.

## Verification

- Focused regression: Fail-before produced `2 failed`; the final source produced `2 passed`.
- Complete affected subsystem: `tests/test_core.py` produced `102 passed`.
- Final full suite: Native `make test` passed with `133 passed` on the exact committed source.
- Static checks: `git diff --check` passed; baseline-aware Ruff found zero new diagnostics and six inherited diagnostics; `ffn/core.py` remained formatter-clean and the test file added no formatter debt. Native `make lint` passed, including Ruff, format, mdformat, and codespell checks.

## Scope

Changed files are limited to `ffn/core.py` and `tests/test_core.py`.

Out of scope: Unifying risk-free price and return conventions, filling risk-free histories, changing `PerformanceStats` scalar recognition, revising calendar intersections, copying caller Series, or redesigning invalid-risk-free validation and atomic failure behavior.