### PR TITLE
Reject constant-return Sharpe samples

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1473,6 +1473,9 @@ def calc_sharpe(returns, rf=0.0, nperiods=None, annualize=True):
     If rf is a non-zero floating scalar, you must specify nperiods. In this case, rf is assumed
     to be expressed in yearly (annualized) terms.
 
+    Returns NaN when the aligned excess returns have no dispersion, independently for each
+    DataFrame column.
+
     Args:
         * returns (Series, DataFrame): Input return series
         * rf (float, np.floating, Series): `Risk-free rate <https://www.investopedia.com/terms/r/risk-freerate.asp>`_ expressed as a yearly (annualized) return or *return*
@@ -1491,8 +1494,26 @@ def calc_sharpe(returns, rf=0.0, nperiods=None, annualize=True):
 
 
 def _calc_sharpe(er, nperiods, annualize=True):
-    """Calculate Sharpe from already aligned excess returns."""
+    """Calculate Sharpe from already aligned excess returns.
+
+    A sample without meaningful dispersion has an undefined Sharpe ratio. Apply that
+    rule independently to each DataFrame column so a constant column does not affect
+    valid neighboring columns.
+    """
     std = er.std(ddof=1)
+
+    # Match the bounded range test established by calc_deflated_sharpe_ratio.
+    # Range identifies identical observations even when std retains rounding residue;
+    # the scale-aware, sample-count-independent floor preserves real quiet variation.
+    spread = er.max() - er.min()
+    scale = er.abs().max()
+    dispersion_floor = 4 * np.finfo(float).eps * scale
+
+    if isinstance(std, pd.Series):
+        std[spread <= dispersion_floor] = np.nan
+    # Short-circuit all-missing nullable Series before comparing pd.NA.
+    elif isinstance(er, pd.Series) and (er.count() == 0 or spread <= dispersion_floor):
+        std = np.nan
     with np.errstate(invalid="ignore", divide="ignore"):
         res = np.divide(er.mean(), std)
 

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1505,14 +1505,17 @@ def _calc_sharpe(er, nperiods, annualize=True):
     # Match the bounded range test established by calc_deflated_sharpe_ratio.
     # Range identifies identical observations even when std retains rounding residue;
     # the scale-aware, sample-count-independent floor preserves real quiet variation.
-    spread = er.max() - er.min()
-    scale = er.abs().max()
-    dispersion_floor = 4 * np.finfo(float).eps * scale
+    # Promote integer extrema before subtraction or abs can overflow.
+    maximum = er.max() * 1.0
+    minimum = er.min() * 1.0
+    spread = maximum - minimum
+    tolerance = 4 * np.finfo(float).eps
+    no_dispersion = (spread <= tolerance * abs(maximum)) | (spread <= tolerance * abs(minimum))
 
     if isinstance(std, pd.Series):
-        std[spread <= dispersion_floor] = np.nan
+        std[no_dispersion] = np.nan
     # Short-circuit all-missing nullable Series before comparing pd.NA.
-    elif isinstance(er, pd.Series) and (er.count() == 0 or spread <= dispersion_floor):
+    elif isinstance(er, pd.Series) and (er.count() == 0 or no_dispersion):
         std = np.nan
     with np.errstate(invalid="ignore", divide="ignore"):
         res = np.divide(er.mean(), std)

--- a/tests/test_performance_ratios.py
+++ b/tests/test_performance_ratios.py
@@ -5,6 +5,86 @@ import pytest
 import ffn
 
 
+def test_sharpe_rejects_series_without_dispersion():
+    """Treat constant effective returns as undefined across supported dtypes."""
+    for dtype in ("float32", "float64", "Float32", "Float64"):
+        for value in (-0.001, 1e-7, 1.0):
+            for length in (3, 250, 5000):
+                returns = pd.Series([value] * length, dtype=dtype)
+                original = returns.copy()
+
+                # The range is an exact oracle even when the sample standard deviation
+                # accumulates floating-point residue for identical stored values.
+                assert returns.max() - returns.min() == 0
+                for risk_free in (0.0, 0.05):
+                    for actual in (
+                        ffn.calc_sharpe(returns, rf=risk_free, nperiods=252),
+                        returns.calc_sharpe(rf=risk_free, nperiods=252),
+                        returns.calc_sharpe_ratio(rf=risk_free, nperiods=252),
+                    ):
+                        assert pd.isna(actual)
+                pd.testing.assert_series_equal(returns, original)
+
+
+def test_sharpe_uses_column_local_excess_dispersion():
+    """Measure dispersion per column after aligning a Series risk-free input."""
+    index = pd.date_range("2026-01-01", periods=8, freq="D")
+    risk_free = pd.Series(np.linspace(0.0001, 0.0008, 6), index=index[:6])
+    excess_returns = pd.DataFrame(
+        {
+            "constant": [0.001] * 6,
+            "missing_constant": [0.001, np.nan, 0.001, 0.001, np.nan, 0.001],
+            "zero": [0.0] * 6,
+            "all_missing": [np.nan] * 6,
+            "varying": [0.001, 0.002, 0.001, 0.003, -0.001, 0.002],
+        },
+        index=index[:6],
+    )
+    returns = excess_returns.add(risk_free, axis="index").reindex(index)
+    original_returns = returns.copy()
+    original_risk_free = risk_free.copy()
+    expected_varying = excess_returns["varying"].mean() / excess_returns["varying"].std(ddof=1) * np.sqrt(252)
+
+    expected = pd.Series(
+        [np.nan, np.nan, np.nan, np.nan, expected_varying],
+        index=returns.columns,
+    )
+    for result in (
+        returns.calc_sharpe(rf=risk_free, nperiods=252),
+        returns.calc_sharpe_ratio(rf=risk_free, nperiods=252),
+    ):
+        actual = pd.Series(result, index=returns.columns)
+        pd.testing.assert_series_equal(actual, expected)
+
+    pd.testing.assert_frame_equal(returns, original_returns)
+    pd.testing.assert_series_equal(risk_free, original_risk_free)
+
+
+def test_sharpe_preserves_quiet_dispersion():
+    """Keep a finite Sharpe ratio for genuinely varying low-volatility data."""
+    returns = pd.Series(1.0 + np.random.default_rng(1).normal(0.0, 1e-12, 5000))
+
+    for scale in (1.0, 1e-7):
+        scaled = returns * scale
+        expected = scaled.mean() / scaled.std(ddof=1) * np.sqrt(252)
+        actual = ffn.calc_sharpe(scaled, nperiods=252)
+
+        assert np.isfinite(actual)
+        assert actual == expected
+
+
+def test_performance_stats_rejects_no_dispersion_sharpe():
+    """Keep zero volatility and undefined Sharpe consistent in performance stats."""
+    prices = pd.Series(2.0 ** np.arange(5), index=pd.bdate_range("2026-01-05", periods=5), name="asset")
+    original = prices.copy()
+
+    stats = ffn.PerformanceStats(prices)
+
+    assert stats.daily_vol == 0
+    assert np.isnan(stats.daily_sharpe)
+    pd.testing.assert_series_equal(prices, original)
+
+
 @pytest.mark.parametrize("dtype", ["float32", "float64", "Float32", "Float64", object])
 @pytest.mark.parametrize("as_frame", [False, True])
 @pytest.mark.parametrize("annualize", [False, True])

--- a/tests/test_performance_ratios.py
+++ b/tests/test_performance_ratios.py
@@ -73,6 +73,31 @@ def test_sharpe_preserves_quiet_dispersion():
         assert actual == expected
 
 
+@pytest.mark.parametrize("dtype", ["int8", "int16", "int32", "int64", "Int8", "Int16", "Int32", "Int64"])
+@pytest.mark.parametrize("as_frame", [False, True])
+def test_sharpe_integer_dispersion_does_not_overflow(dtype, as_frame):
+    minimum = np.iinfo(dtype.lower()).min
+    returns = pd.Series([minimum, 0, -minimum - 1], dtype=dtype, name="varying")
+    constant = pd.Series([minimum] * 3, dtype=dtype, name="constant")
+    if as_frame:
+        missing = pd.Series([pd.NA] * 3, dtype="Float64", name="all_missing")
+        returns = pd.concat([returns, constant, missing], axis=1)
+    original = returns.copy()
+    expected = returns.mean() / returns.std(ddof=1) * np.sqrt(252)
+    if as_frame:
+        expected.iloc[1] = np.nan
+
+    actual = ffn.calc_sharpe(returns, rf=0, nperiods=252)
+
+    if as_frame:
+        pd.testing.assert_series_equal(actual, expected)
+        pd.testing.assert_frame_equal(returns, original)
+    else:
+        assert actual == expected
+        assert pd.isna(ffn.calc_sharpe(constant, rf=0, nperiods=252))
+        pd.testing.assert_series_equal(returns, original)
+
+
 def test_performance_stats_rejects_no_dispersion_sharpe():
     """Keep zero volatility and undefined Sharpe consistent in performance stats."""
     prices = pd.Series(2.0 ** np.arange(5), index=pd.bdate_range("2026-01-05", periods=5), name="asset")


### PR DESCRIPTION
## Summary

Return the established undefined-ratio result for mathematically constant excess returns instead of exposing floating-point residue as an enormous finite Sharpe ratio.

A 250-observation Series containing only `0.001` has pandas sample standard deviation `2.1727542076e-19` and accepted `calc_sharpe` returns `7.3061682775e16`, although the series has no dispersion.

## Behavior

A constant effective excess-return sample has no defined Sharpe ratio, represented by `NaN` for a Series/scalar result and independently for each DataFrame column. The same invariant applies to `PerformanceStats` fields reached through `_calc_sharpe`. Dispersion handling uses the aligned excess-return sample, is scale-aware, and preserves genuinely varying quiet series, container shape, labels, dtype behavior, and input ownership.

## Regression evidence

Three temporary tests failed on accepted `6478764`: the exact constant Series returned `7.306168277482229e16`, the constant column in a mixed DataFrame returned `inf` while its varying neighbor remained correct, and a partially aligned Series risk-free input with six identical effective excess returns returned `inf`. Across 64 constant cases spanning four ordinary/nullable dtypes, four scales, and four lengths, all 64 incorrectly returned either infinity (`55`) or a huge finite value (`9`). A five-price binary-exact growth sequence also produced `daily_vol == 0.0` with `PerformanceStats.daily_sharpe == inf`.

## Verification

- Focused regression: With the permanent tests present and the production guard absent, the focused selection failed `6/7` cases for the intended reason; the quiet-varying control passed. Against the final implementation, the consolidated focused selection passed `4/4`.
- Complete affected subsystem: The final workflow run passed all `77` tests in `tests/test_performance_ratios.py` and all `105` tests in `tests/test_core.py` (`182` total).
- Final full suite: The post-refresh native `make test` run passed all `324` tests. Native `make lint` also passed before the clean pre-publication receipt was written.
- Static, documentation, API, dependency, or build checks: Ruff reported zero new or inherited diagnostics in the two changed files; both files match their formatter baselines; changed-line Pyright reported zero unapproved diagnostics and `878` inherited/indirect diagnostics. No new Python file required format-new. Sphinx `8.2.3` built the declared documentation with warnings as errors and exposed the updated public docstring. The final Python `3.9.6`, pandas `1.5.3`, NumPy `1.26.4` focused run passed `4/4`; the modern Python `3.11.16`, pandas `3.0.5`, NumPy `2.4.6` run is covered by the main verification. Private downstream/boundary controls passed during implementation, and duplicate-label and nullable-panel probes were rerun on the final diff. The four existing statistics benchmarks passed after reassessment with means from `2.46 ms` to `44.89 ms`, showing no material regression against the assessed `2.64 ms` to `46.60 ms` range. The final repository-wide caller scan found only the relevant core/tests and ordinary quickstart/docs consumers; no generated record or additional integration target required an update.

## Scope

Changed files are limited to `ffn/core.py` and `tests/test_performance_ratios.py`.

Out of scope: changing Sharpe annualization, Sortino downside conventions, risk-free alignment, deflated-Sharpe/FDR algorithms, or applying an unbounded absolute epsilon.