### PR TITLE
Preserve precision when limiting weights

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -2169,7 +2169,7 @@ def limit_weights(weights, limit=0.1):
     if np.round(weights.sum(), 1) != 1.0:
         raise ValueError(f"Expecting weights (that sum to 1) - sum is {weights.sum()}")
 
-    res = np.round(weights.copy(), 4)
+    res = weights.copy()
     to_rebalance = (res[res > limit] - limit).sum()
 
     ok = res[res < limit]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -670,6 +670,21 @@ def test_limit_weights():
     aae(actual["e"], 0.300, 3)
 
 
+def test_limit_weights_preserves_precision():
+    """Preserve the original budget during proportional redistribution."""
+    weights = pd.Series([0.50006, 0.29997, 0.19997], index=["a", "b", "c"])
+    expected = pd.Series(
+        [0.5, 0.3000060007200864, 0.1999939992799136],
+        index=weights.index,
+    )
+
+    actual = ffn.core.limit_weights(weights, limit=0.5)
+
+    pd.testing.assert_series_equal(actual, expected)
+    assert actual.sum() == 1.0
+    assert actual.max() <= 0.5
+
+
 def test_random_weights():
     PANDAS_VERSION = Version(pd.__version__)
     PANDAS_210 = PANDAS_VERSION >= Version("2.1.0")


### PR DESCRIPTION
## Summary

Stop rounding currently accepted strictly positive portfolio weights to four decimal places before applying the existing proportional cap, preserving the original one-unit budget and redistribution proportions without changing validation or degenerate-input policy.

For `[0.50006, 0.29997, 0.19997]` and `limit=0.5`, accepted code first rounds to `[0.5001, 0.3000, 0.2000]`, then returns `[0.5, 0.30006, 0.20004]` with total `1.0001`. Direct full-precision redistribution caps the first weight's `0.00006` excess and allocates it in the original `0.29997:0.19997` ratio, yielding `[0.5, 0.3000060007200864, 0.1999939992799136]` with total `1.0`.

## Behavior

For inputs already accepted by the current function with a nonzero eligible redistribution pool, preserve the original one-unit budget, enforce the existing cap, and redistribute excess proportionally to the original uncapped weights. Preserve the public signature, current validation and exceptions, Series and explicit dict behavior, historical ndarray behavior, labels, names, return representations, and input non-mutation.

## Regression evidence

On accepted `4c1b4c4`, the deterministic active-limiting assertion failed: two of three values differed from the independently calculated result, maximum absolute difference was `5.39992799e-05`, and the actual total was `1.0001` instead of `1.0`. A deterministic six-asset `calc_inv_vol_weights` result also summed to `1.0` before limiting but `0.9999` afterward both with a redundant cap and an active cap, demonstrating a normal optimizer-weight workflow rather than only a synthetic no-op.

## Verification

- Focused regression: fail-before produced accepted output `[0.5, 0.30006, 0.20004]`; the post-rebase run passed `1/1`.
- Complete affected core module: `106 passed` after the clean rebase and format-new preflight.
- Final full suite: Native lint and distribution-content checks passed, and the coverage suite passed all `341` repository tests.
- Static checks: `git diff --check` passed; baseline-aware Ruff found zero new diagnostics and six inherited test-file diagnostics; `ffn/core.py` remained formatter-clean and `tests/test_core.py` retained only accepted formatting debt; changed-line Pyright found zero unapproved diagnostics and reported 1,296 inherited or indirect diagnostics.

## Scope

Changed files are limited to `ffn/core.py`, `tests/test_core.py`

Out of scope: Zero eligible-pool behavior, negative or non-finite weights, invalid totals, non-numeric or non-positive limits, exact equal-weight feasibility boundaries, new tolerances or exception types, long/short semantics, docstring cleanup, and neighboring weighting functions.