### PR TITLE
Honor risk targets in SLSQP risk parity

### DIFF
--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1774,36 +1774,39 @@ def calc_mean_var_weights(returns, weight_bounds=(0.0, 1.0), rf=0.0, covar_metho
 
 def _erc_weights_slsqp(x0, cov, b, maximum_iterations, tolerance):
     """
-    Calculates the equal risk contribution / risk parity weights given
-        a DataFrame of returns.
+    Calculates long-only risk-budget weights with SLSQP.
+
+    The objective matches each asset's raw component contribution to its
+    requested share of portfolio variance. Both the target and covariance are
+    normalized so equivalent target proportions and return units produce the
+    same optimization problem.
 
     Args:
-    * x0 (np.array): Starting asset weights.
-    * cov (np.array): covariance matrix.
-    * b (np.array): Risk target weights. By definition target total risk contributions are all equal which makes this redundant.
-    * maximum_iterations (int): Maximum iterations in iterative solutions.
-    * tolerance (float): Tolerance level in iterative solutions.
+        * x0 (np.array): Starting asset weights.
+        * cov (np.array): Covariance matrix.
+        * b (np.array): Relative risk target weights.
+        * maximum_iterations (int): Maximum iterations in iterative solutions.
+        * tolerance (float): Tolerance level in iterative solutions.
 
     Returns:
-    np.array {weight}
+        np.array {weight}
 
     You can read more about ERC at
     http://thierry-roncalli.com/download/erc.pdf
 
     """
+    b = np.asarray(b) / np.sum(b)
+    covariance_scale = np.mean(np.diagonal(cov))
+    # Keep SLSQP's absolute tolerance independent of the units used for returns.
+    if np.isfinite(covariance_scale) and covariance_scale > 0:
+        cov = cov / covariance_scale
 
     def fitness(weights, covar):
-        # total risk contributions
-        # trc = weights*np.matmul(covar,weights)/np.sqrt(np.matmul(weights.T,np.matmul(covar,weights)))
-
-        # instead of using the true definition for trc we will use the optimization on page 5
+        # Raw component contributions sum to portfolio variance.
         trc = weights * np.matmul(covar, weights)
-
-        # sum of squared differences of total risk contributions
-        # switched from squared deviations to absolute deviations to avoid numerical instability
-        sse = np.sum(np.abs(trc - trc.reshape((-1, 1))))
-        # minimizes metric
-        return sse
+        target_trc = b * trc.sum()
+        # Preserve the accepted absolute-deviation objective's numerical stability.
+        return np.sum(np.abs(trc - target_trc))
 
     # nonnegative
     bounds = [(0, None) for i in range(len(x0))]

--- a/ffn/core.py
+++ b/ffn/core.py
@@ -1795,7 +1795,12 @@ def _erc_weights_slsqp(x0, cov, b, maximum_iterations, tolerance):
     http://thierry-roncalli.com/download/erc.pdf
 
     """
-    b = np.asarray(b) / np.sum(b)
+    b = np.asarray(b)
+    # Keep SLSQP's finite-difference steps visible with low-precision targets.
+    b = b.astype(np.result_type(b.dtype, np.float64), copy=False)
+    # Scale before summing so finite positive targets cannot overflow their total.
+    b = b / np.max(b)
+    b = b / np.sum(b)
     covariance_scale = np.mean(np.diagonal(cov))
     # Keep SLSQP's absolute tolerance independent of the units used for returns.
     if np.isfinite(covariance_scale) and covariance_scale > 0:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -534,6 +534,103 @@ def test_calc_erc_weights(df):
     aae(actual["C"], 0.356, 3)
 
 
+def test_calc_erc_weights_slsqp_honors_risk_target():
+    """Honor a non-equal target through both public paths and covariance methods."""
+    target = np.array([0.8, 0.1, 0.1])
+    covariance = np.array([[0.04, 0.012, 0.008], [0.012, 0.09, 0.018], [0.008, 0.018, 0.16]])
+    returns = pd.DataFrame(
+        np.random.default_rng(20260909).multivariate_normal(np.zeros(3), covariance, 500),
+        columns=list("ABC"),
+    )
+    original_returns = returns.copy()
+    original_target = target.copy()
+
+    covariance_cases = (
+        ("standard", returns.cov().to_numpy(dtype=float)),
+        ("ledoit-wolf", ffn.core.sklearn.covariance.ledoit_wolf(returns)[0]),
+    )
+    for covar_method, estimated_covariance in covariance_cases:
+        assert isinstance(estimated_covariance, np.ndarray)
+        # CCD is the accepted control: it already applies the same relative target.
+        ccd = ffn.calc_erc_weights(
+            returns,
+            risk_weights=target,
+            covar_method=covar_method,
+            risk_parity_method="ccd",
+            tolerance=1e-9,
+        )
+        assert isinstance(ccd, pd.Series)
+        ccd_weights = ccd.to_numpy(dtype=float)
+        ccd_contributions = ccd_weights * (estimated_covariance @ ccd_weights)
+        # Allow CCD's established iterative accuracy; SLSQP is checked more tightly below.
+        np.testing.assert_allclose(ccd_contributions / ccd_contributions.sum(), target, atol=5e-6)
+
+        for actual in (
+            ffn.calc_erc_weights(
+                returns,
+                risk_weights=target,
+                covar_method=covar_method,
+                risk_parity_method="slsqp",
+                tolerance=1e-9,
+            ),
+            returns.calc_erc_weights(
+                risk_weights=target,
+                covar_method=covar_method,
+                risk_parity_method="slsqp",
+                tolerance=1e-9,
+            ),
+        ):
+            assert isinstance(actual, pd.Series)
+            weights = actual.to_numpy(dtype=float)
+            # Reconstruct the contribution shares independently from the optimizer objective.
+            contributions = weights * (estimated_covariance @ weights)
+            np.testing.assert_allclose(contributions / contributions.sum(), target, atol=1e-6)
+            assert isinstance(actual.index, pd.Index)
+            pd.testing.assert_index_equal(actual.index, returns.columns)
+            assert actual.name == "erc"
+            assert np.isfinite(weights).all()
+            assert (weights >= 0).all()
+            np.testing.assert_allclose(weights.sum(), 1.0, atol=1e-10)
+
+    pd.testing.assert_frame_equal(returns, original_returns)
+    np.testing.assert_array_equal(target, original_target)
+
+
+def test_calc_erc_weights_slsqp_matches_diagonal_risk_target():
+    """Match the diagonal oracle across equivalent target and return scales."""
+    signs = np.array(
+        [
+            [1.0, 1.0, 1.0],
+            [1.0, -1.0, -1.0],
+            [-1.0, 1.0, -1.0],
+            [-1.0, -1.0, 1.0],
+        ]
+    )
+    returns = pd.DataFrame(signs * np.array([0.01, 0.02, 0.04]), columns=list("ABC"))
+    target = np.array([0.8, 0.1, 0.1])
+    original_returns = returns.copy()
+    original_target = target.copy()
+
+    # Orthogonal centered columns give a diagonal sample covariance and a closed form.
+    covariance = returns.cov().to_numpy(dtype=float)
+    expected = np.sqrt(target / np.diag(covariance))
+    expected /= expected.sum()
+    for return_scale in (1.0, 1e-4):
+        for target_scale in (1.0, 10.0):
+            actual = ffn.calc_erc_weights(
+                returns * return_scale,
+                risk_weights=target * target_scale,
+                covar_method="standard",
+                risk_parity_method="slsqp",
+                tolerance=1e-9,
+            )
+            assert isinstance(actual, pd.Series)
+            np.testing.assert_allclose(actual.to_numpy(dtype=float), expected, atol=1e-6)
+
+    pd.testing.assert_frame_equal(returns, original_returns)
+    np.testing.assert_array_equal(target, original_target)
+
+
 def test_calc_total_return(df):
     prc = df.iloc[0:11]
     actual = prc.calc_total_return()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -615,17 +615,27 @@ def test_calc_erc_weights_slsqp_matches_diagonal_risk_target():
     covariance = returns.cov().to_numpy(dtype=float)
     expected = np.sqrt(target / np.diag(covariance))
     expected /= expected.sum()
+    equivalent_targets = (
+        target,
+        target * 10,
+        target.astype("float32"),
+        np.array([8_000_000_000_000_000_000, 1_000_000_000_000_000_000, 1_000_000_000_000_000_000], dtype="int64"),
+        np.array([3.2e38, 4e37, 4e37], dtype="float32"),
+        np.array([1.6e308, 2e307, 2e307]),
+    )
     for return_scale in (1.0, 1e-4):
-        for target_scale in (1.0, 10.0):
+        for scaled_target in equivalent_targets:
+            original_scaled_target = scaled_target.copy()
             actual = ffn.calc_erc_weights(
                 returns * return_scale,
-                risk_weights=target * target_scale,
+                risk_weights=scaled_target,
                 covar_method="standard",
                 risk_parity_method="slsqp",
                 tolerance=1e-9,
             )
             assert isinstance(actual, pd.Series)
             np.testing.assert_allclose(actual.to_numpy(dtype=float), expected, atol=1e-6)
+            np.testing.assert_array_equal(scaled_target, original_scaled_target)
 
     pd.testing.assert_frame_equal(returns, original_returns)
     np.testing.assert_array_equal(target, original_target)


### PR DESCRIPTION
## Summary

Make the existing SLSQP branch honor an already-valid finite, correct-length, strictly positive non-equal `risk_weights` target instead of silently solving the equal-contribution equation for every target, without changing the public signature, solver selection, covariance estimators, or CCD implementation.

Four orthogonal three-asset returns with scales `[0.01, 0.02, 0.04]` have an exactly diagonal sample covariance. For target `[0.8, 0.1, 0.1]`, current SLSQP returns inverse-volatility weights `[0.57142857, 0.28571429, 0.14285714]` and normalized risk contributions `[1/3, 1/3, 1/3]`; the independently derived risk-budget weights are `[0.79041071, 0.13972619, 0.06986310]`.

## Behavior

For the bounded valid-target domain above and a well-conditioned long-only covariance problem, SLSQP's raw component contributions must be proportional to the normalized requested target, while weights remain finite and nonnegative, retain input-column labels, and sum to one. The default equal target retains current equal-contribution results. This contract does not claim that a local SLSQP optimizer has CCD's global convergence guarantee for every covariance matrix or starting point.

## Regression evidence

A disposable five-case pytest regression against accepted `6478764` failed exactly as expected for module and pandas entry points with both standard and Ledoit-Wolf covariance and for the diagonal closed-form oracle. Every requested target produced equal thirds; the closed-form case differed in all three weights with maximum absolute error `0.21898214`. A separate seeded 500-observation fixture produced `[0.33333337, 0.33333326, 0.33333337]` instead of `[0.8, 0.1, 0.1]` for standard covariance and equal thirds for Ledoit-Wolf, while CCD reached the target in both cases. The ignored-target result also reproduced in the supported Python 3.9/pandas 1.5/NumPy 1 compatibility lane.

## Verification

- Focused regression: The two permanent regressions failed before the fix for the intended reason (`2 failed, 105 deselected`): SLSQP produced equal-third contributions for the requested `[0.8, 0.1, 0.1]` target and inverse-volatility weights instead of the diagonal oracle. They passed again after the final rebase (`2 passed`). The broader disposable assessment matrix also failed `5/5` cases against accepted `6478764`.
- Complete affected subsystem: `tests/test_core.py` passed all `108` tests on the exact rebased source (`108 passed`).
- Final full suite: Native lint and distribution-content checks passed, and the coverage suite passed all `343` repository tests on exact rebased commit `b014485`.
- Static, documentation, API, dependency, or build checks: Differential Ruff found `0` new and `6` inherited diagnostics. Ruff format accepted `ffn/core.py`; `tests/test_core.py` retains baseline format debt and its changed lines were manually reviewed. Pyright found `0` unapproved diagnostics, `3` exact branch-specific private-profile diagnostics caused solely by the accepted native untyped helper signature, and `1296` inherited or indirect diagnostics. The private wrapper records each exact path, line, rule, message, count, accepted-upstream precedent, and reason; no upstream annotation, cast, suppression, or typing import was added. The post-rebase `format-new` preview confirmed that no Python file was added. The whitespace check (`git diff --check`) passed. The existing ERC benchmark passed both parameterizations, and a direct SLSQP timing probe remained about `3.2 ms` for the three-asset case. A read-only end-to-end check through downstream `bt.algos.WeighERC` at `2ab842d` honored the target and preserved labels and budget. The private wrapper doctor passed, its touched file passes its selected Ruff checks and formatter, and all `205` shared workflow tests pass against the rebased private state.

## Scope

Changed files are limited to `ffn/core.py`, `tests/test_core.py`

Out of scope: Input-validation policy and degenerate covariance from PR 27; changing the default CCD solver or CCD math; new global-convergence guarantees; shorting, minimum variance, public signatures, covariance estimators, broad docs, and unrelated optimizer cleanup.