### PR TITLE
Isolate memoized data from caller mutation

### DIFF
--- a/ffn/utils.py
+++ b/ffn/utils.py
@@ -29,16 +29,21 @@ def _memoize(func, *args, **kw):
 
     cache = func.mcache
     if not refresh and key in cache:
-        return cache[key]
-    else:
-        cache[key] = result = func(*args, **kw)
-        return result
+        result = cache[key]
+        return result.copy(deep=True) if isinstance(result, (pd.Series, pd.DataFrame)) else result
+
+    result = func(*args, **kw)
+    # Keep the cached pandas snapshot private from the caller receiving this result.
+    cache[key] = result.copy(deep=True) if isinstance(result, (pd.Series, pd.DataFrame)) else result
+    return result
 
 
 def memoize(f, refresh_keyword="mrefresh"):
     """
     Memoize decorator. The refresh keyword is the keyword
     used to bypass the cache (in the function call).
+    Pandas Series and DataFrame results are copied at the cache boundary
+    so assignments through returned containers do not change cached data.
     """
     f.mcache = {}
     f.mrefresh_keyword = refresh_keyword

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -10,6 +10,26 @@ def sample_provider(ticker, field):
     return pd.Series(prices[ticker], index=pd.date_range("2024-01-01", periods=4))
 
 
+def test_get_isolates_cached_data_from_caller_mutation():
+    """Keep caller assignments from changing data cached by ``ffn.get``."""
+    expected = pd.DataFrame(
+        {"abc": [10.0, 12.0]},
+        index=pd.date_range("2024-01-02", periods=2, freq="2D"),
+    )
+    ffn.get.mcache.clear()
+    try:
+        first = ffn.get("ABC", provider=sample_provider)
+        assert isinstance(first, pd.DataFrame)
+        first.iloc[0, 0] = 999.0
+        second = ffn.get("ABC", provider=sample_provider)
+
+        assert isinstance(second, pd.DataFrame)
+        assert second is not first
+        pd.testing.assert_frame_equal(second, expected)
+    finally:
+        ffn.get.mcache.clear()
+
+
 @pytest.mark.parametrize("forward_fill", [False, True])
 @pytest.mark.parametrize("common_dates", [False, True])
 def test_get_forward_fill(forward_fill, common_dates):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,68 @@ import ffn
 from ffn import utils
 
 
+def test_memoize_isolates_series_results():
+    """Keep caller assignments from changing a cached Series snapshot."""
+    index = pd.date_range("2024-01-01", periods=2, name="date")
+    expected = pd.Series([100.0, 101.0], index=index, name="price")
+    expected.attrs["provider"] = "fixture"
+    calls = []
+
+    @utils.memoize
+    def cached(value):
+        """Return fresh data when the decorated function runs."""
+        calls.append(value)
+        return expected.copy(deep=True)
+
+    first = cached("value")
+    assert isinstance(first, pd.Series)
+    first.iloc[0] = 999.0
+    second = cached("value")
+    assert isinstance(second, pd.Series)
+    assert second is not first
+    pd.testing.assert_series_equal(second, expected)
+    assert second.attrs == expected.attrs
+
+    second.iloc[-1] = -1.0
+    third = cached("value")
+    assert isinstance(third, pd.Series)
+    assert third is not second
+    pd.testing.assert_series_equal(third, expected)
+    assert third.attrs == expected.attrs
+    assert calls == ["value"]
+
+
+def test_memoize_isolates_dataframe_results():
+    """Keep caller assignments from changing a cached DataFrame snapshot."""
+    index = pd.date_range("2024-01-01", periods=2, name="date")
+    expected = pd.DataFrame({"price": [100.0, 101.0]}, index=index)
+    expected.attrs["provider"] = "fixture"
+    calls = []
+
+    @utils.memoize
+    def cached(value):
+        """Return fresh data when the decorated function runs."""
+        calls.append(value)
+        return expected.copy(deep=True)
+
+    first = cached("value")
+    assert isinstance(first, pd.DataFrame)
+    first.iloc[0, 0] = 999.0
+    second = cached("value")
+    assert isinstance(second, pd.DataFrame)
+    assert second is not first
+    pd.testing.assert_frame_equal(second, expected)
+    assert second.attrs == expected.attrs
+
+    second.iloc[-1, 0] = -1.0
+    third = cached("value")
+    assert isinstance(third, pd.DataFrame)
+    assert third is not second
+    pd.testing.assert_frame_equal(third, expected)
+    assert third.attrs == expected.attrs
+    assert calls == ["value"]
+
+
 def test_memoize_handles_keyword_only_refresh():
     calls = []
 


### PR DESCRIPTION
## Summary

Prevent mutation of one returned `ffn.get` DataFrame from changing the cached value returned by later identical requests.

A deterministic provider returned `[100.0, 101.0]`; after the first `ffn.get("ABC", provider=provider)` result was changed to `999.0`, an identical second request made no provider call and returned the same object containing `999.0`.

## Behavior

Memoization may avoid provider work, but a mutable result handed to one caller must not expose the private cached snapshot to caller mutation.

## Regression evidence

The provider-call count remained one, object identity was shared, and the second value was `999.0` instead of the independent provider value `100.0` on both the oldest and newest supported pandas/NumPy bands.

## Verification

- Focused regression: Accepted `c4d3f80` called the provider once, returned the identical object, and produced `999.0` instead of the independently retained `100.0` on the second request. Direct `ffn.data.csv` and isolated `memoize` Series/DataFrame probes failed the same invariant.
- Pass-after focused regressions: `3 passed, 19 deselected` for the separate Series, DataFrame, and exported `ffn.get` ownership paths. The Python 3.9/pandas 1.5.3/NumPy 1.26.4 boundary also passed all three; the local Python 3.11/pandas 3.0.5/NumPy 2.4.6 environment covers the newest supported band.
- Complete affected subsystem: `tests/test_utils.py tests/test_data.py` passed all `22` tests; the independent utility-module run passed all `17` tests.
- Static and formatting: `git diff --check` and Ruff passed all three changed Python files with zero new diagnostics. Changed-line Pyright had zero unapproved diagnostics; fourteen exact decorator-stub diagnostics are recorded as private native-style allowances. `ffn/utils.py` and `tests/test_data.py` pass Ruff format; `tests/test_utils.py` retains only its accepted-upstream whole-file formatting debt, and its added lines were reviewed manually. `format-new` found no newly added Python files.
- Private downstream controls: nullable Series metadata, refresh calls, direct `ffn.data.csv` isolation, and unchanged non-pandas identity all passed. The implementation checkpoint did not require the full repository suite because the change does not alter configuration, exports, pandas extensions, packaging, or another subsystem.
- Final pre-publication verification: On the exact rebased commit, `make lint` and `make checks` passed, `make coverage` passed all `346` repository tests, and `make docs` completed without warnings. The final clean receipt also records `18` focused/utility tests, all `5` data tests, zero new Ruff findings, formatter-baseline parity, and zero unapproved changed-line Pyright diagnostics.

## Scope

Changed files are limited to `ffn/utils.py`, `tests/test_utils.py`, and `tests/test_data.py`.

Out of scope: Disk caching, provider retries, cache eviction, credential handling, and unrelated provider behavior.